### PR TITLE
v1.0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 /Output
+AssetTrakr.App/GeneratedSyncfusionLicense.cs

--- a/AssetTrakr.Alerts/AlertGenerator.cs
+++ b/AssetTrakr.Alerts/AlertGenerator.cs
@@ -15,6 +15,7 @@ namespace AssetTrakr.Alerts
         internal int _thresholdValue = 0;
         internal DateOnly _thresholdDate;
         internal List<SystemSetting> _alertPreferences;
+        public bool IsUpdateAvailable = false;
 
         public AlertGenerator()
         {
@@ -47,6 +48,16 @@ namespace AssetTrakr.Alerts
             AssetAlerts(includeArchived);
             LicenseAlerts(includeArchived);
             ContractAlerts(includeArchived);
+
+            if(IsUpdateAvailable)
+            {
+                _alerts.Add(new Alert
+                {
+                    Category = ActionAlertCategory.System,
+                    Description = "You are not running the latest version",
+                    Severity = Severity.Severe,
+                });
+            }
 
             return _alerts;
         }

--- a/AssetTrakr.Alerts/AssetTrakr.Alerts.csproj
+++ b/AssetTrakr.Alerts/AssetTrakr.Alerts.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetTrakr.App.Migrator/AssetTrakr.App.Migrator.csproj
+++ b/AssetTrakr.App.Migrator/AssetTrakr.App.Migrator.csproj
@@ -11,7 +11,7 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <Description>AssetTrakr.  Track Assets, Licenses, and Contracts for free.</Description>
-    <Copyright>Laim McKenzie</Copyright>
+    <Copyright>McKenzie Software</Copyright>
     <Title>AssetTrakr.Setup.App</Title>
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>AssetTrakr.App.Migrator.Program</StartupObject>

--- a/AssetTrakr.App.Migrator/Program.cs
+++ b/AssetTrakr.App.Migrator/Program.cs
@@ -16,7 +16,7 @@ namespace AssetTrakr.App.Migrator
             ApplicationConfiguration.Initialize();
 
             LogManager logManager = new("setupApp.log");
-            LogManager.Information("Initialize...");
+            LogManager.Information("Initialize...", nameof(Program));
 
             Application.Run(new FrmDatabaseUpgrade());
         }

--- a/AssetTrakr.App.Migrator/Program.cs
+++ b/AssetTrakr.App.Migrator/Program.cs
@@ -16,7 +16,7 @@ namespace AssetTrakr.App.Migrator
             ApplicationConfiguration.Initialize();
 
             LogManager logManager = new("setupApp.log");
-            LogManager.Information("Initialize...", nameof(Program));
+            LogManager.Information("Initialize...", typeof(Program));
 
             Application.Run(new FrmDatabaseUpgrade());
         }

--- a/AssetTrakr.App/AssetTrakr.App.csproj
+++ b/AssetTrakr.App/AssetTrakr.App.csproj
@@ -26,6 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
+    <PackageReference Include="Syncfusion.SfDataGrid.WinForms" Version="25.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AssetTrakr.App/AssetTrakr.App.csproj
+++ b/AssetTrakr.App/AssetTrakr.App.csproj
@@ -13,7 +13,7 @@
     <SelfContained>false</SelfContained>
     <ApplicationIcon>ATIcon-256.ico</ApplicationIcon>
     <Description>AssetTrakr.  Track Assets, Licenses, and Contracts for free.</Description>
-    <Copyright>Laim McKenzie</Copyright>
+    <Copyright>McKenzie Software</Copyright>
     <Title>AssetTrakr</Title>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>

--- a/AssetTrakr.App/AssetTrakr.App.csproj
+++ b/AssetTrakr.App/AssetTrakr.App.csproj
@@ -53,7 +53,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
-    <PackageReference Include="Syncfusion.SfDataGrid.WinForms" Version="25.2.5" />
+    <PackageReference Include="Syncfusion.SfDataGrid.WinForms" Version="26.1.35" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AssetTrakr.App/AssetTrakr.App.csproj
+++ b/AssetTrakr.App/AssetTrakr.App.csproj
@@ -13,12 +13,38 @@
     <SelfContained>false</SelfContained>
     <ApplicationIcon>ATIcon-256.ico</ApplicationIcon>
     <Description>AssetTrakr.  Track Assets, Licenses, and Contracts for free.</Description>
-    <Copyright>McKenzie Software</Copyright>
+    <Copyright>$([System.DateTime]::Now.Year) McKenzie Software</Copyright>
     <Title>AssetTrakr</Title>
     <PlatformTarget>x64</PlatformTarget>
+
+	<SyncfusionLicense>nullkey</SyncfusionLicense>
+
+	<StartupObject>AssetTrakr.App.Program</StartupObject>
   </PropertyGroup>
 
-  <ItemGroup>
+  <Target Name="GenerateSyncfusionLicenseClass" BeforeTargets="BeforeBuild">
+    <Message Text="Generating Syncfusion License Class" />
+    <PropertyGroup>
+      <ClassData>
+      <![CDATA[
+      namespace AssetTrakr.App
+      {
+          public static class SyncfusionInfo
+          {
+              public const string LicenseKey = "$(SyncfusionLicense)"%3b // percentage 3 b is a semicolon
+          }
+      }
+      ]]>
+      </ClassData>
+    </PropertyGroup>
+    <WriteLinesToFile File="GeneratedSyncfusionLicense.cs" Overwrite="true" Lines="$(ClassData)" />
+    <ItemGroup>
+		<Compile Remove="GeneratedSyncfusionLicense.cs"></Compile>
+		<Compile Include="GeneratedSyncfusionLicense.cs"></Compile>
+    </ItemGroup>
+  </Target>
+
+	<ItemGroup>
     <PackageReference Include="EPPlus" Version="7.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">

--- a/AssetTrakr.App/AssetTrakr.App.csproj
+++ b/AssetTrakr.App/AssetTrakr.App.csproj
@@ -52,7 +52,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
-    <PackageReference Include="Syncfusion.SfDataGrid.WinForms" Version="25.2.4" />
+    <PackageReference Include="Syncfusion.SfDataGrid.WinForms" Version="25.2.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AssetTrakr.App/AssetTrakr.App.csproj
+++ b/AssetTrakr.App/AssetTrakr.App.csproj
@@ -22,6 +22,7 @@
 	<StartupObject>AssetTrakr.App.Program</StartupObject>
   </PropertyGroup>
 
+  <!-- This depends on SyncfusinLicense in PropertyGroup which can be set during build with /p:SyncfusionLicense=XXX -->
   <Target Name="GenerateSyncfusionLicenseClass" BeforeTargets="BeforeBuild">
     <Message Text="Generating Syncfusion License Class" />
     <PropertyGroup>

--- a/AssetTrakr.App/Forms/Asset/FrmAssetModify.cs
+++ b/AssetTrakr.App/Forms/Asset/FrmAssetModify.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using System.ComponentModel;
 using System.Diagnostics;
 using AssetTrakr.WinForms.ActionLog;
+using AssetTrakr.Extensions;
 
 namespace AssetTrakr.App.Forms.Asset
 {
@@ -373,9 +374,8 @@ namespace AssetTrakr.App.Forms.Asset
 
         private void btnAddUpdate_Click(object sender, EventArgs e)
         {
-            if (txtName.Text.Length > 155 || txtName.Text.Length == 0)
+            if (txtName.IsRequired("Name", 155))
             {
-                MessageBox.Show("Name is a required field and must be be less than 156 characters", "Name", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -600,7 +600,11 @@ namespace AssetTrakr.App.Forms.Asset
             if (_warrantyPeriods.Count == 0)
             {
                 cbHasWarranty.Checked = false;
-                MessageBox.Show("No Warranty Periods added so HasWarranty will be unchecked", "Warranty", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+
+                if(cbHasWarranty.Checked)
+                {
+                    MessageBox.Show("No Warranty Periods added so HasWarranty will be unchecked", "Warranty", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
             }
 
             List<AssetHardDrive> driveList = [];

--- a/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.Designer.cs
+++ b/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.Designer.cs
@@ -30,7 +30,6 @@
         {
             components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmAssetViewAll));
-            dgvViewAll = new DataGridView();
             cmsDgvRightClick = new ContextMenuStrip(components);
             columnSelectorToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator1 = new ToolStripSeparator();
@@ -43,35 +42,10 @@
             archiveOrUnarchiveToolStripMenuItem = new ToolStripMenuItem();
             lblNoAssetsTitle = new Label();
             lblNoAssetsDescription = new Label();
-            ((System.ComponentModel.ISupportInitialize)dgvViewAll).BeginInit();
+            sfDgViewAll = new Syncfusion.WinForms.DataGrid.SfDataGrid();
             cmsDgvRightClick.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)sfDgViewAll).BeginInit();
             SuspendLayout();
-            // 
-            // dgvViewAll
-            // 
-            dgvViewAll.AllowUserToAddRows = false;
-            dgvViewAll.AllowUserToDeleteRows = false;
-            dgvViewAll.AllowUserToOrderColumns = true;
-            dgvViewAll.AllowUserToResizeRows = false;
-            dgvViewAll.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
-            dgvViewAll.BackgroundColor = Color.White;
-            dgvViewAll.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dgvViewAll.ContextMenuStrip = cmsDgvRightClick;
-            dgvViewAll.Dock = DockStyle.Fill;
-            dgvViewAll.Location = new Point(0, 0);
-            dgvViewAll.MultiSelect = false;
-            dgvViewAll.Name = "dgvViewAll";
-            dgvViewAll.ReadOnly = true;
-            dgvViewAll.RowHeadersVisible = false;
-            dgvViewAll.RowHeadersWidth = 51;
-            dgvViewAll.RowHeadersWidthSizeMode = DataGridViewRowHeadersWidthSizeMode.DisableResizing;
-            dgvViewAll.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
-            dgvViewAll.ShowCellErrors = false;
-            dgvViewAll.ShowCellToolTips = false;
-            dgvViewAll.ShowEditingIcon = false;
-            dgvViewAll.ShowRowErrors = false;
-            dgvViewAll.Size = new Size(1098, 661);
-            dgvViewAll.TabIndex = 19;
             // 
             // cmsDgvRightClick
             // 
@@ -157,29 +131,52 @@
             lblNoAssetsDescription.TabIndex = 21;
             lblNoAssetsDescription.Text = "No Assets have been added to the system.  Add some Assets to see them here.";
             // 
+            // sfDgViewAll
+            // 
+            sfDgViewAll.AccessibleName = "Table";
+            sfDgViewAll.AllowEditing = false;
+            sfDgViewAll.AllowFiltering = true;
+            sfDgViewAll.AutoSizeColumnsMode = Syncfusion.WinForms.DataGrid.Enums.AutoSizeColumnsMode.Fill;
+            sfDgViewAll.ContextMenuStrip = cmsDgvRightClick;
+            sfDgViewAll.Dock = DockStyle.Fill;
+            sfDgViewAll.Location = new Point(0, 0);
+            sfDgViewAll.Name = "sfDgViewAll";
+            sfDgViewAll.PreviewRowHeight = 35;
+            sfDgViewAll.ShowBusyIndicator = true;
+            sfDgViewAll.ShowGroupDropArea = true;
+            sfDgViewAll.ShowHeaderToolTip = true;
+            sfDgViewAll.Size = new Size(1098, 661);
+            sfDgViewAll.Style.BorderColor = Color.FromArgb(100, 100, 100);
+            sfDgViewAll.Style.CheckBoxStyle.CheckedBackColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.CheckBoxStyle.CheckedBorderColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.CheckBoxStyle.IndeterminateBorderColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.HyperlinkStyle.DefaultLinkColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.TabIndex = 28;
+            sfDgViewAll.Text = "sfDataGrid1";
+            sfDgViewAll.SelectionChanged += sfDgViewAll_SelectionChanged;
+            sfDgViewAll.DataSourceChanged += sfDgViewAll_DataSourceChanged;
+            // 
             // FrmAssetViewAll
             // 
             AutoScaleDimensions = new SizeF(8F, 20F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.White;
             ClientSize = new Size(1098, 661);
+            Controls.Add(sfDgViewAll);
             Controls.Add(lblNoAssetsDescription);
             Controls.Add(lblNoAssetsTitle);
-            Controls.Add(dgvViewAll);
             FormBorderStyle = FormBorderStyle.FixedToolWindow;
             Icon = (Icon)resources.GetObject("$this.Icon");
             Name = "FrmAssetViewAll";
             StartPosition = FormStartPosition.CenterParent;
             Text = "View All Assets";
-            ((System.ComponentModel.ISupportInitialize)dgvViewAll).EndInit();
             cmsDgvRightClick.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)sfDgViewAll).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
 
         #endregion
-
-        private DataGridView dgvViewAll;
         private ContextMenuStrip cmsDgvRightClick;
         private ToolStripMenuItem columnSelectorToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator1;
@@ -192,5 +189,6 @@
         private ToolStripMenuItem deleteToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator3;
         private ToolStripMenuItem archiveOrUnarchiveToolStripMenuItem;
+        private Syncfusion.WinForms.DataGrid.SfDataGrid sfDgViewAll;
     }
 }

--- a/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.Designer.cs
+++ b/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.Designer.cs
@@ -165,8 +165,9 @@
             Controls.Add(sfDgViewAll);
             Controls.Add(lblNoAssetsDescription);
             Controls.Add(lblNoAssetsTitle);
-            FormBorderStyle = FormBorderStyle.FixedToolWindow;
+            FormBorderStyle = FormBorderStyle.FixedSingle;
             Icon = (Icon)resources.GetObject("$this.Icon");
+            MinimizeBox = false;
             Name = "FrmAssetViewAll";
             StartPosition = FormStartPosition.CenterParent;
             Text = "View All Assets";

--- a/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.cs
+++ b/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.cs
@@ -67,6 +67,7 @@ namespace AssetTrakr.App.Forms.Asset
                     a.AssetId,
                     a.Name,
                     a.Model,
+                    a.Purchased,
                     a.Hardware.AssetType,
                     Manufacturer = a.Manufacturer.Name ?? "",
                     Platform = a.Platform.Name ?? "",

--- a/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.cs
+++ b/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.cs
@@ -118,6 +118,11 @@ namespace AssetTrakr.App.Forms.Asset
             dgvViewAll.Columns[nameof(Models.Assets.Asset.UpdatedBy)].Visible = false;
             dgvViewAll.Columns[nameof(Models.Assets.Asset.CreatedBy)].Visible = false;
 
+            if(!_includeArchived)
+            {
+                dgvViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
+            }
+
             if (!assets.Any())
             {
                 dgvViewAll.Visible = false;

--- a/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.cs
+++ b/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.cs
@@ -261,6 +261,8 @@ namespace AssetTrakr.App.Forms.Asset
         private void sfDgViewAll_DataSourceChanged(object sender, Syncfusion.WinForms.DataGrid.Events.DataSourceChangedEventArgs e)
         {
             sfDgViewAll.CustomColumnModifier<Models.Assets.Asset>(_includeArchived);
+
+            sfDgViewAll.Columns["WarrantyPeriodsFormatted"].HeaderText = "Warranty Periods";
         }
     }
 }

--- a/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.cs
+++ b/AssetTrakr.App/Forms/Asset/FrmAssetViewAll.cs
@@ -7,6 +7,7 @@ using AssetTrakr.Logging;
 using AssetTrakr.Utils.Enums;
 using AssetTrakr.WinForms.ActionLog;
 using System.Xml.Linq;
+using Syncfusion.WinForms.DataGrid;
 
 namespace AssetTrakr.App.Forms.Asset
 {
@@ -15,6 +16,8 @@ namespace AssetTrakr.App.Forms.Asset
 
         private readonly DatabaseContext _dbContext;
         private readonly bool _includeArchived = false;
+        private Models.Assets.Asset? _selectedAsset;
+        private bool _firstLoad = true;
 
         public FrmAssetViewAll()
         {
@@ -23,13 +26,17 @@ namespace AssetTrakr.App.Forms.Asset
             _dbContext ??= new DatabaseContext();
 
             _includeArchived = _dbContext.SystemSettings.WhereEnabled(nameof(SystemSettings.IncludeArchivedInViewAll));
+
+            Activated += AfterLoading;
         }
 
-        protected override void OnLoad(EventArgs e)
+        private async void AfterLoading(object? sender, EventArgs e)
         {
-            base.OnLoad(e);
-
-            LoadData();
+            if (_firstLoad)
+            {
+                await LoadData();
+                _firstLoad = false;
+            }
         }
 
         /// <summary>
@@ -38,18 +45,18 @@ namespace AssetTrakr.App.Forms.Asset
         /// <param name="needReload">
         /// True or False, true resets the datasource to NULL before loading data
         /// </param>
-        private void LoadData(bool needReload = false)
+        private async Task LoadData(bool needReload = false)
         {
             if (needReload)
             {
-                dgvViewAll.DataSource = null;
+                sfDgViewAll.DataSource = null;
             }
 
-            dgvViewAll.Visible = true;
+            sfDgViewAll.Visible = true;
             lblNoAssetsDescription.Visible = false;
             lblNoAssetsTitle.Visible = false;
 
-            var assets = _dbContext.Assets
+            var assets = await _dbContext.Assets
                 .Include(a => a.Manufacturer)
                 .Include(a => a.Contract)
                 .Include(a => a.AssetAttachments)
@@ -60,7 +67,7 @@ namespace AssetTrakr.App.Forms.Asset
                     a.AssetId,
                     a.Name,
                     a.Model,
-                    Type = a.Hardware.AssetType,
+                    a.Hardware.AssetType,
                     Manufacturer = a.Manufacturer.Name ?? "",
                     Platform = a.Platform.Name ?? "",
                     Contract = a.Contract.Name ?? "",
@@ -85,47 +92,14 @@ namespace AssetTrakr.App.Forms.Asset
                     a.IsArchived
                 })
                 .Where(a => _includeArchived || !a.IsArchived)
-                .ToList();
+                .ToListAsync();
 
-            dgvViewAll.DataSource = assets;
+            sfDgViewAll.DataSource = assets;
 
-            // Rename columns since it's an anonymous type and ignores the [DisplayName] attribute in the Asset Model
-            dgvViewAll.Columns[nameof(AssetHardware.RamSizeInGB)].HeaderText = "RAM (GB)";
-            dgvViewAll.Columns[nameof(AssetHardware.BiosSerialNumber)].HeaderText = "Bios Serial Number";
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.LicenseKey)].HeaderText = "License Key";
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.OperatingSystem)].HeaderText = "Operating System";
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.OrderReference)].HeaderText = "Order Reference";
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.RegisteredUser)].HeaderText = "User";
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.RegisteredEmail)].HeaderText = "Email";
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].HeaderText = "Archived";
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.IsUnderWarranty)].HeaderText = "Has Warranty";
-            dgvViewAll.Columns["WarrantyPeriodsFormatted"].HeaderText = "Warranty";
-
-            // Hide Columns
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.AssetId)].Visible = false;
-            dgvViewAll.Columns[nameof(AssetHardware.Processor)].Visible = false;
-            dgvViewAll.Columns[nameof(AssetHardware.RamSizeInGB)].Visible = false;
-            dgvViewAll.Columns[nameof(AssetHardware.BiosSerialNumber)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.LicenseKey)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.Contract)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.OrderReference)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.Price)].Visible = false;
-            dgvViewAll.Columns["Attachments"].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.RegisteredUser)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.RegisteredEmail)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.CreatedDate)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.UpdatedDate)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.UpdatedBy)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Assets.Asset.CreatedBy)].Visible = false;
-
-            if(!_includeArchived)
-            {
-                dgvViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
-            }
 
             if (!assets.Any())
             {
-                dgvViewAll.Visible = false;
+                sfDgViewAll.Visible = false;
                 lblNoAssetsDescription.Visible = true;
                 lblNoAssetsTitle.Visible = true;
             }
@@ -134,61 +108,64 @@ namespace AssetTrakr.App.Forms.Asset
 
         private void columnSelectorToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (cmsDgvRightClick.SourceControl is not SfDataGrid dgv)
             {
                 return;
             }
 
-            FrmColumnSelector2 frmColumnSelector = new(dgv);
+            FrmColumnSelector2 frmColumnSelector = new(sfDgv: dgv);
             frmColumnSelector.ShowDialog();
 
-            foreach (DataGridViewColumn col in dgv.Columns)
+            foreach (var col in dgv.Columns)
             {
-                col.Visible = frmColumnSelector.SelectedColumns.Contains(col.Name);
+                col.Visible = frmColumnSelector.SelectedColumns.Contains(col.HeaderText);
             }
         }
 
         private void exportToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            dgvViewAll.Export();
+            sfDgViewAll.Export();
         }
 
         private void viewToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedAsset == null)
             {
+                MessageBox.Show("Unable to open asset as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            FrmAssetModify FrmAssetModify = new((int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[0].Value, true);
+            FrmAssetModify FrmAssetModify = new(assetId: _selectedAsset.AssetId, isReadOnly: true);
             FrmAssetModify.ShowDialog();
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedAsset == null)
             {
+                MessageBox.Show("Unable to open asset as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            FrmAssetModify FrmAssetModify = new((int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[0].Value);
+            FrmAssetModify FrmAssetModify = new(assetId: _selectedAsset.AssetId);
             FrmAssetModify.ShowDialog();
-            LoadData(true);
+            await LoadData(true);
         }
 
-        private void deleteToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void deleteToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedAsset == null)
             {
+                MessageBox.Show("Unable to open asset as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            string name = (string)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Assets.Asset.Name)].Value;
+            string name = _selectedAsset.Name;
             DialogResult dr = MessageBox.Show($"This action cannot be reversed, do you wish to delete {name}?", "Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
             if (dr == DialogResult.Yes)
             {
-                var assetId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Assets.Asset.AssetId)].Value;
+                var assetId = _selectedAsset.AssetId;
 
                 try
                 {
@@ -196,7 +173,7 @@ namespace AssetTrakr.App.Forms.Asset
                     {
                         ActionLogMethods.Deleted(_dbContext, ActionAlertCategory.Asset, name);
 
-                        LoadData(true);
+                        await LoadData(true);
                     }
                 }
                 catch (Exception ex)
@@ -207,21 +184,22 @@ namespace AssetTrakr.App.Forms.Asset
             }
         }
 
-        private void archiveOrUnarchiveToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void archiveOrUnarchiveToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedAsset == null)
             {
+                MessageBox.Show("Unable to open asset as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
-            
+
             string? tooltipName = archiveOrUnarchiveToolStripMenuItem.Text;
 
-            string name = (string)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Assets.Asset.Name)].Value;
+            string name = _selectedAsset.Name;
             DialogResult dr = MessageBox.Show($"Do you wish to {tooltipName} {name}?", "Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
             if (dr != DialogResult.Yes) { return; }
 
-            var assetId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Assets.Asset.AssetId)].Value;
+            var assetId = _selectedAsset.AssetId;
             var asset = _dbContext.Assets.FirstOrDefault(a => a.AssetId == assetId);
 
             if (asset == null) { return; }
@@ -242,7 +220,7 @@ namespace AssetTrakr.App.Forms.Asset
                     ActionLogMethods.Unarchived(_dbContext, ActionAlertCategory.Asset, name);
                 }
 
-                LoadData(true);
+                await LoadData(true);
             }
             catch (DbUpdateException ex)
             {
@@ -258,20 +236,30 @@ namespace AssetTrakr.App.Forms.Asset
 
         private void cmsDgvRightClick_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            // If the item is already in the archive, change the archive tool item to unarchive and disable editing
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedAsset == null)
             {
+                cmsDgvRightClick.HideItems();
                 return;
             }
+            cmsDgvRightClick.ShowItems();
 
-            var assetId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Assets.Asset.AssetId)].Value;
-            var asset = _dbContext.Assets.FirstOrDefault(a => a.AssetId == assetId);
+            // If the item is already in the archive, change the archive tool item to unarchive and disable editing
+            var asset = _selectedAsset;
 
             if (asset == null) { return; }
 
             editToolStripMenuItem.Enabled = editToolStripMenuItem.Visible = !asset.IsArchived;
             archiveOrUnarchiveToolStripMenuItem.Text = asset.IsArchived ? "Unarchive" : "Archive";
         }
-    
+
+        private void sfDgViewAll_SelectionChanged(object sender, Syncfusion.WinForms.DataGrid.Events.SelectionChangedEventArgs e)
+        {
+            _selectedAsset = sfDgViewAll.GetCurrentItemProperty<Models.Assets.Asset>(nameof(Models.Assets.Asset.AssetId), _dbContext);
+        }
+
+        private void sfDgViewAll_DataSourceChanged(object sender, Syncfusion.WinForms.DataGrid.Events.DataSourceChangedEventArgs e)
+        {
+            sfDgViewAll.CustomColumnModifier<Models.Assets.Asset>(_includeArchived);
+        }
     }
 }

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.Designer.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.Designer.cs
@@ -42,9 +42,9 @@
             toolStripSeparator3 = new ToolStripSeparator();
             deleteToolStripMenuItem = new ToolStripMenuItem();
             archiveOrUnarchiveToolStripMenuItem = new ToolStripMenuItem();
-            dgvViewAll = new Syncfusion.WinForms.DataGrid.SfDataGrid();
+            sfDgViewAll = new Syncfusion.WinForms.DataGrid.SfDataGrid();
             cmsDgvRightClick.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)dgvViewAll).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)sfDgViewAll).BeginInit();
             SuspendLayout();
             // 
             // lblNoContractsDescription
@@ -133,30 +133,30 @@
             archiveOrUnarchiveToolStripMenuItem.Text = "Archive";
             archiveOrUnarchiveToolStripMenuItem.Click += archiveOrUnarchiveToolStripMenuItem_Click;
             // 
-            // dgvViewAll
+            // sfDgViewAll
             // 
-            dgvViewAll.AccessibleName = "Table";
-            dgvViewAll.AllowEditing = false;
-            dgvViewAll.AllowFiltering = true;
-            dgvViewAll.AutoSizeColumnsMode = Syncfusion.WinForms.DataGrid.Enums.AutoSizeColumnsMode.Fill;
-            dgvViewAll.ContextMenuStrip = cmsDgvRightClick;
-            dgvViewAll.Dock = DockStyle.Fill;
-            dgvViewAll.Location = new Point(0, 0);
-            dgvViewAll.Name = "dgvViewAll";
-            dgvViewAll.PreviewRowHeight = 35;
-            dgvViewAll.ShowBusyIndicator = true;
-            dgvViewAll.ShowGroupDropArea = true;
-            dgvViewAll.ShowHeaderToolTip = true;
-            dgvViewAll.Size = new Size(1098, 661);
-            dgvViewAll.Style.BorderColor = Color.FromArgb(100, 100, 100);
-            dgvViewAll.Style.CheckBoxStyle.CheckedBackColor = Color.FromArgb(0, 120, 215);
-            dgvViewAll.Style.CheckBoxStyle.CheckedBorderColor = Color.FromArgb(0, 120, 215);
-            dgvViewAll.Style.CheckBoxStyle.IndeterminateBorderColor = Color.FromArgb(0, 120, 215);
-            dgvViewAll.Style.HyperlinkStyle.DefaultLinkColor = Color.FromArgb(0, 120, 215);
-            dgvViewAll.TabIndex = 27;
-            dgvViewAll.Text = "sfDataGrid1";
-            dgvViewAll.SelectionChanged += dgvViewAll_SelectionChanged;
-            dgvViewAll.DataSourceChanged += dgvViewAll_DataSourceChanged;
+            sfDgViewAll.AccessibleName = "Table";
+            sfDgViewAll.AllowEditing = false;
+            sfDgViewAll.AllowFiltering = true;
+            sfDgViewAll.AutoSizeColumnsMode = Syncfusion.WinForms.DataGrid.Enums.AutoSizeColumnsMode.Fill;
+            sfDgViewAll.ContextMenuStrip = cmsDgvRightClick;
+            sfDgViewAll.Dock = DockStyle.Fill;
+            sfDgViewAll.Location = new Point(0, 0);
+            sfDgViewAll.Name = "sfDgViewAll";
+            sfDgViewAll.PreviewRowHeight = 35;
+            sfDgViewAll.ShowBusyIndicator = true;
+            sfDgViewAll.ShowGroupDropArea = true;
+            sfDgViewAll.ShowHeaderToolTip = true;
+            sfDgViewAll.Size = new Size(1098, 661);
+            sfDgViewAll.Style.BorderColor = Color.FromArgb(100, 100, 100);
+            sfDgViewAll.Style.CheckBoxStyle.CheckedBackColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.CheckBoxStyle.CheckedBorderColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.CheckBoxStyle.IndeterminateBorderColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.HyperlinkStyle.DefaultLinkColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.TabIndex = 27;
+            sfDgViewAll.Text = "sfDataGrid1";
+            sfDgViewAll.SelectionChanged += dgvViewAll_SelectionChanged;
+            sfDgViewAll.DataSourceChanged += dgvViewAll_DataSourceChanged;
             // 
             // FrmContractViewAll
             // 
@@ -164,7 +164,7 @@
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.White;
             ClientSize = new Size(1098, 661);
-            Controls.Add(dgvViewAll);
+            Controls.Add(sfDgViewAll);
             Controls.Add(lblNoContractsDescription);
             Controls.Add(lblNoContractsTitle);
             FormBorderStyle = FormBorderStyle.FixedSingle;
@@ -174,7 +174,7 @@
             StartPosition = FormStartPosition.CenterParent;
             Text = "View All Contracts";
             cmsDgvRightClick.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)dgvViewAll).EndInit();
+            ((System.ComponentModel.ISupportInitialize)sfDgViewAll).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -193,6 +193,6 @@
         private ToolStripMenuItem deleteToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator3;
         private ToolStripMenuItem archiveOrUnarchiveToolStripMenuItem;
-        private Syncfusion.WinForms.DataGrid.SfDataGrid dgvViewAll;
+        private Syncfusion.WinForms.DataGrid.SfDataGrid sfDgViewAll;
     }
 }

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.Designer.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.Designer.cs
@@ -32,7 +32,6 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmContractViewAll));
             lblNoContractsDescription = new Label();
             lblNoContractsTitle = new Label();
-            dgvViewAll = new DataGridView();
             cmsDgvRightClick = new ContextMenuStrip(components);
             columnSelectorToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator1 = new ToolStripSeparator();
@@ -43,8 +42,9 @@
             toolStripSeparator3 = new ToolStripSeparator();
             deleteToolStripMenuItem = new ToolStripMenuItem();
             archiveOrUnarchiveToolStripMenuItem = new ToolStripMenuItem();
-            ((System.ComponentModel.ISupportInitialize)dgvViewAll).BeginInit();
+            dgvViewAll = new Syncfusion.WinForms.DataGrid.SfDataGrid();
             cmsDgvRightClick.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)dgvViewAll).BeginInit();
             SuspendLayout();
             // 
             // lblNoContractsDescription
@@ -67,32 +67,6 @@
             lblNoContractsTitle.Size = new Size(202, 41);
             lblNoContractsTitle.TabIndex = 25;
             lblNoContractsTitle.Text = "No Contracts";
-            // 
-            // dgvViewAll
-            // 
-            dgvViewAll.AllowUserToAddRows = false;
-            dgvViewAll.AllowUserToDeleteRows = false;
-            dgvViewAll.AllowUserToOrderColumns = true;
-            dgvViewAll.AllowUserToResizeRows = false;
-            dgvViewAll.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
-            dgvViewAll.BackgroundColor = Color.White;
-            dgvViewAll.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dgvViewAll.ContextMenuStrip = cmsDgvRightClick;
-            dgvViewAll.Dock = DockStyle.Fill;
-            dgvViewAll.Location = new Point(0, 0);
-            dgvViewAll.MultiSelect = false;
-            dgvViewAll.Name = "dgvViewAll";
-            dgvViewAll.ReadOnly = true;
-            dgvViewAll.RowHeadersVisible = false;
-            dgvViewAll.RowHeadersWidth = 51;
-            dgvViewAll.RowHeadersWidthSizeMode = DataGridViewRowHeadersWidthSizeMode.DisableResizing;
-            dgvViewAll.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
-            dgvViewAll.ShowCellErrors = false;
-            dgvViewAll.ShowCellToolTips = false;
-            dgvViewAll.ShowEditingIcon = false;
-            dgvViewAll.ShowRowErrors = false;
-            dgvViewAll.Size = new Size(1098, 661);
-            dgvViewAll.TabIndex = 24;
             // 
             // cmsDgvRightClick
             // 
@@ -159,22 +133,47 @@
             archiveOrUnarchiveToolStripMenuItem.Text = "Archive";
             archiveOrUnarchiveToolStripMenuItem.Click += archiveOrUnarchiveToolStripMenuItem_Click;
             // 
+            // dgvViewAll
+            // 
+            dgvViewAll.AccessibleName = "Table";
+            dgvViewAll.AllowEditing = false;
+            dgvViewAll.AllowFiltering = true;
+            dgvViewAll.AutoSizeColumnsMode = Syncfusion.WinForms.DataGrid.Enums.AutoSizeColumnsMode.Fill;
+            dgvViewAll.ContextMenuStrip = cmsDgvRightClick;
+            dgvViewAll.Dock = DockStyle.Fill;
+            dgvViewAll.Location = new Point(0, 0);
+            dgvViewAll.Name = "dgvViewAll";
+            dgvViewAll.PreviewRowHeight = 35;
+            dgvViewAll.ShowBusyIndicator = true;
+            dgvViewAll.ShowGroupDropArea = true;
+            dgvViewAll.ShowHeaderToolTip = true;
+            dgvViewAll.Size = new Size(1098, 661);
+            dgvViewAll.Style.BorderColor = Color.FromArgb(100, 100, 100);
+            dgvViewAll.Style.CheckBoxStyle.CheckedBackColor = Color.FromArgb(0, 120, 215);
+            dgvViewAll.Style.CheckBoxStyle.CheckedBorderColor = Color.FromArgb(0, 120, 215);
+            dgvViewAll.Style.CheckBoxStyle.IndeterminateBorderColor = Color.FromArgb(0, 120, 215);
+            dgvViewAll.Style.HyperlinkStyle.DefaultLinkColor = Color.FromArgb(0, 120, 215);
+            dgvViewAll.TabIndex = 27;
+            dgvViewAll.Text = "sfDataGrid1";
+            dgvViewAll.SelectionChanged += dgvViewAll_SelectionChanged;
+            dgvViewAll.DataSourceChanged += dgvViewAll_DataSourceChanged;
+            // 
             // FrmContractViewAll
             // 
             AutoScaleDimensions = new SizeF(8F, 20F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.White;
             ClientSize = new Size(1098, 661);
+            Controls.Add(dgvViewAll);
             Controls.Add(lblNoContractsDescription);
             Controls.Add(lblNoContractsTitle);
-            Controls.Add(dgvViewAll);
             FormBorderStyle = FormBorderStyle.FixedToolWindow;
             Icon = (Icon)resources.GetObject("$this.Icon");
             Name = "FrmContractViewAll";
             StartPosition = FormStartPosition.CenterParent;
             Text = "View All Contracts";
-            ((System.ComponentModel.ISupportInitialize)dgvViewAll).EndInit();
             cmsDgvRightClick.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)dgvViewAll).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -183,7 +182,6 @@
 
         private Label lblNoContractsDescription;
         private Label lblNoContractsTitle;
-        private DataGridView dgvViewAll;
         private ContextMenuStrip cmsDgvRightClick;
         private ToolStripMenuItem columnSelectorToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator1;
@@ -194,5 +192,6 @@
         private ToolStripMenuItem deleteToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator3;
         private ToolStripMenuItem archiveOrUnarchiveToolStripMenuItem;
+        private Syncfusion.WinForms.DataGrid.SfDataGrid dgvViewAll;
     }
 }

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.Designer.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.Designer.cs
@@ -167,8 +167,9 @@
             Controls.Add(dgvViewAll);
             Controls.Add(lblNoContractsDescription);
             Controls.Add(lblNoContractsTitle);
-            FormBorderStyle = FormBorderStyle.FixedToolWindow;
+            FormBorderStyle = FormBorderStyle.FixedSingle;
             Icon = (Icon)resources.GetObject("$this.Icon");
+            MinimizeBox = false;
             Name = "FrmContractViewAll";
             StartPosition = FormStartPosition.CenterParent;
             Text = "View All Contracts";

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
@@ -84,11 +84,6 @@ namespace AssetTrakr.App.Forms.Contract
 
             sfDgViewAll.DataSource = contracts;
 
-            if (!_includeArchived)
-            {
-                sfDgViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
-            }
-
             if (!contracts.Any())
             {
                 sfDgViewAll.Visible = false;
@@ -269,6 +264,12 @@ namespace AssetTrakr.App.Forms.Contract
             if(sfDgViewAll.Columns.Count == 0)
             {
                 return;
+            }
+
+            // hide the archive column if the system setting include archived is not enabled
+            if (!_includeArchived)
+            {
+                sfDgViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
             }
 
             sfDgViewAll.Columns[nameof(Models.Contract.ContractId)].Visible = false;

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
@@ -51,10 +51,10 @@ namespace AssetTrakr.App.Forms.Contract
         {
             if (needReload)
             {
-                dgvViewAll.DataSource = null;
+                sfDgViewAll.DataSource = null;
             }
 
-            dgvViewAll.Visible = true;
+            sfDgViewAll.Visible = true;
             lblNoContractsDescription.Visible = false;
             lblNoContractsTitle.Visible = false;
 
@@ -82,16 +82,16 @@ namespace AssetTrakr.App.Forms.Contract
                 .Where(c => _includeArchived || !c.IsArchived)
                 .ToListAsync();
 
-            dgvViewAll.DataSource = contracts;
+            sfDgViewAll.DataSource = contracts;
 
             if (!_includeArchived)
             {
-                dgvViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
+                sfDgViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
             }
 
             if (!contracts.Any())
             {
-                dgvViewAll.Visible = false;
+                sfDgViewAll.Visible = false;
                 lblNoContractsDescription.Visible = true;
                 lblNoContractsTitle.Visible = true;
             }
@@ -116,7 +116,7 @@ namespace AssetTrakr.App.Forms.Contract
 
         private void exportToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            dgvViewAll.Export();
+            sfDgViewAll.Export();
         }
 
         private async void editToolStripMenuItem_Click(object sender, EventArgs e)
@@ -246,12 +246,12 @@ namespace AssetTrakr.App.Forms.Contract
 
         private void dgvViewAll_SelectionChanged(object sender, Syncfusion.WinForms.DataGrid.Events.SelectionChangedEventArgs e)
         {
-            if (dgvViewAll.CurrentItem != null)
+            if (sfDgViewAll.CurrentItem != null)
             {
 
-                var test = dgvViewAll.CurrentItem.GetType();
+                var test = sfDgViewAll.CurrentItem.GetType();
 
-                object? v = test.GetProperty("ContractId")?.GetValue(dgvViewAll.CurrentItem, null);
+                object? v = test.GetProperty("ContractId")?.GetValue(sfDgViewAll.CurrentItem, null);
 
                 if(v == null)
                 {
@@ -266,18 +266,18 @@ namespace AssetTrakr.App.Forms.Contract
         private void dgvViewAll_DataSourceChanged(object sender, Syncfusion.WinForms.DataGrid.Events.DataSourceChangedEventArgs e)
         {
             // hide non-default columns
-            if(dgvViewAll.Columns.Count == 0)
+            if(sfDgViewAll.Columns.Count == 0)
             {
                 return;
             }
 
-            dgvViewAll.Columns[nameof(Models.Contract.ContractId)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.Description)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.CreatedDate)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.UpdatedDate)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.UpdatedBy)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.CreatedBy)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.ComboDisplayName)].Visible = false;
+            sfDgViewAll.Columns[nameof(Models.Contract.ContractId)].Visible = false;
+            sfDgViewAll.Columns[nameof(Models.Contract.Description)].Visible = false;
+            sfDgViewAll.Columns[nameof(Models.Contract.CreatedDate)].Visible = false;
+            sfDgViewAll.Columns[nameof(Models.Contract.UpdatedDate)].Visible = false;
+            sfDgViewAll.Columns[nameof(Models.Contract.UpdatedBy)].Visible = false;
+            sfDgViewAll.Columns[nameof(Models.Contract.CreatedBy)].Visible = false;
+            sfDgViewAll.Columns[nameof(Models.Contract.ComboDisplayName)].Visible = false;
         }
 
     }

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
@@ -6,13 +6,19 @@ using AssetTrakr.Logging;
 using AssetTrakr.Utils.Enums;
 using AssetTrakr.WinForms.ActionLog;
 using Microsoft.EntityFrameworkCore;
+using Syncfusion.Data.Extensions;
+using Syncfusion.WinForms.DataGrid;
+using System.Data;
 
 namespace AssetTrakr.App.Forms.Contract
 {
     public partial class FrmContractViewAll : Form
     {
-        private readonly DatabaseContext _dbContext;
+        private DatabaseContext _dbContext;
         private readonly bool _includeArchived = false;
+        private Models.Contract? _selectedContract;
+        private bool _firstLoad = true;
+
 
         public FrmContractViewAll()
         {
@@ -21,14 +27,19 @@ namespace AssetTrakr.App.Forms.Contract
             _dbContext ??= new DatabaseContext();
 
             _includeArchived = _dbContext.SystemSettings.WhereEnabled(nameof(SystemSettings.IncludeArchivedInViewAll));
+
+            Activated += AfterLoading;
         }
 
-        protected override void OnLoad(EventArgs e)
+        private async void AfterLoading(object? sender, EventArgs e)
         {
-            base.OnLoad(e);
-
-            LoadData();
+            if(_firstLoad)
+            {
+                await LoadData();
+                _firstLoad = false;
+            }
         }
+
 
         /// <summary>
         /// Loads all of the Contracts data into the DataGridView
@@ -36,10 +47,7 @@ namespace AssetTrakr.App.Forms.Contract
         /// <param name="needReload">
         /// True or False, true resets the datasource to NULL before loading data
         /// </param>
-        /// <param name="includeArchived">
-        /// True or False, true includes archived entities in the result
-        /// </param>
-        private void LoadData(bool needReload = false)
+        private async Task LoadData(bool needReload = false)
         {
             if (needReload)
             {
@@ -50,24 +58,31 @@ namespace AssetTrakr.App.Forms.Contract
             lblNoContractsDescription.Visible = false;
             lblNoContractsTitle.Visible = false;
 
-            var contracts = _dbContext.Contracts.Where(c => _includeArchived || !c.IsArchived).ToList();
+            //var contracts = await _dbContext.Contracts.Where(c => _includeArchived || !c.IsArchived).ToListAsync();
+
+            var contracts = await _dbContext.Contracts
+                .Select(c => new
+                {
+                    c.ContractId,
+                    c.Name,
+                    c.OrderRef,
+                    c.UserAgreementId,
+                    c.PaymentFrequency,
+                    c.Price,
+                    c.IsArchived,
+                    c.ComboDisplayName,
+                    c.Description,
+                    c.CreatedDate,
+                    c.UpdatedDate,
+                    c.CreatedBy,
+                    c.UpdatedBy,
+                    c.ContractPeriods,
+                    c.ContractAttachments
+                })
+                .Where(c => _includeArchived || !c.IsArchived)
+                .ToListAsync();
 
             dgvViewAll.DataSource = contracts;
-
-            // Rename columns since it's an anonymous type and ignores [DisplayName] attribute in the License model
-            dgvViewAll.Columns[nameof(Models.Contract.OrderRef)].HeaderText = "Order Reference";
-            dgvViewAll.Columns[nameof(Models.Contract.PaymentFrequency)].HeaderText = "Pay Frequency";
-            dgvViewAll.Columns[nameof(Models.Contract.ComboDisplayName)].HeaderText = "Name & User Agreement Id";
-            dgvViewAll.Columns[nameof(Models.Contract.UserAgreementId)].HeaderText = "User Agreement Id";
-
-            // hide columns
-            dgvViewAll.Columns[nameof(Models.Contract.ContractId)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.Description)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.CreatedDate)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.UpdatedDate)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.UpdatedBy)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.CreatedBy)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.Contract.ComboDisplayName)].Visible = false;
 
             if (!_includeArchived)
             {
@@ -80,21 +95,22 @@ namespace AssetTrakr.App.Forms.Contract
                 lblNoContractsDescription.Visible = true;
                 lblNoContractsTitle.Visible = true;
             }
+
         }
 
         private void columnSelectorToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (cmsDgvRightClick.SourceControl is not SfDataGrid dgv)
             {
                 return;
             }
 
-            FrmColumnSelector2 frmColumnSelector = new(dgv);
+            FrmColumnSelector2 frmColumnSelector = new(sfDgv: dgv);
             frmColumnSelector.ShowDialog();
 
-            foreach (DataGridViewColumn col in dgv.Columns)
+            foreach (var col in dgv.Columns)
             {
-                col.Visible = frmColumnSelector.SelectedColumns.Contains(col.Name);
+                col.Visible = frmColumnSelector.SelectedColumns.Contains(col.MappingName);
             }
         }
 
@@ -103,42 +119,45 @@ namespace AssetTrakr.App.Forms.Contract
             dgvViewAll.Export();
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedContract == null)
             {
+                MessageBox.Show("Unable to open contract as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            FrmContractModify frmContractModify = new(contractId: (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[0].Value);
+            FrmContractModify frmContractModify = new(contractId: _selectedContract.ContractId);
             frmContractModify.ShowDialog();
-            LoadData(true);
+            await LoadData(true);
         }
 
         private void viewToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedContract == null)
             {
+                MessageBox.Show("Unable to open contract as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            FrmContractModify frmContractModify = new(contractId: (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[0].Value, isReadOnly: true);
+            FrmContractModify frmContractModify = new(contractId: _selectedContract.ContractId, isReadOnly: true);
             frmContractModify.ShowDialog();
         }
 
-        private void deleteToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void deleteToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedContract == null)
             {
+                MessageBox.Show("Unable to open contract as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            string name = (string)dgv.Rows[dgv.SelectedRows[0].Index].Cells["Name"].Value;
+            string name = _selectedContract.Name;
             DialogResult dr = MessageBox.Show($"This action cannot be reversed, do you wish to delete {name}?", "Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
             if (dr == DialogResult.Yes)
             {
-                var contractId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[0].Value;
+                var contractId = _selectedContract.ContractId;
 
                 try
                 {
@@ -146,7 +165,7 @@ namespace AssetTrakr.App.Forms.Contract
                     {
                         ActionLogMethods.Deleted(_dbContext, ActionAlertCategory.Contract, name);
 
-                        LoadData(true);
+                        await LoadData(true);
                     }
                 }
                 catch (Exception ex)
@@ -157,22 +176,22 @@ namespace AssetTrakr.App.Forms.Contract
             }
         }
 
-        private void archiveOrUnarchiveToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void archiveOrUnarchiveToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedContract == null)
             {
+                MessageBox.Show("Unable to open contract as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             string? tooltipName = archiveOrUnarchiveToolStripMenuItem.Text;
 
-            string name = (string)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Contract.Name)].Value;
+            string name = _selectedContract.Name;
             DialogResult dr = MessageBox.Show($"Do you wish to {tooltipName} {name}?", "Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
             if (dr != DialogResult.Yes) { return; }
 
-            var contractId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Contract.ContractId)].Value;
-            var contract = _dbContext.Contracts.FirstOrDefault(a => a.ContractId == contractId);
+            var contract = _selectedContract;
 
             if (contract == null) { return; }
 
@@ -192,7 +211,7 @@ namespace AssetTrakr.App.Forms.Contract
                     ActionLogMethods.Unarchived(_dbContext, ActionAlertCategory.Contract, name);
                 }
 
-                LoadData(true);
+                await LoadData(true);
             }
             catch (DbUpdateException ex)
             {
@@ -208,14 +227,15 @@ namespace AssetTrakr.App.Forms.Contract
 
         private void cmsDgvRightClick_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            // If the item is already in the archive, change the archive tool item to unarchive and disable editing
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedContract == null)
             {
+                cmsDgvRightClick.HideItems();
                 return;
             }
+            cmsDgvRightClick.ShowItems();
 
-            var contractId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Contract.ContractId)].Value;
-            var contract = _dbContext.Contracts.FirstOrDefault(c => c.ContractId == contractId);
+            // If the item is already in the archive, change the archive tool item to unarchive and disable editing
+            var contract = _selectedContract;
 
             if (contract == null) { return; }
 
@@ -223,5 +243,42 @@ namespace AssetTrakr.App.Forms.Contract
             archiveOrUnarchiveToolStripMenuItem.Text = contract.IsArchived ? "Unarchive" : "Archive";
 
         }
+
+        private void dgvViewAll_SelectionChanged(object sender, Syncfusion.WinForms.DataGrid.Events.SelectionChangedEventArgs e)
+        {
+            if (dgvViewAll.CurrentItem != null)
+            {
+
+                var test = dgvViewAll.CurrentItem.GetType();
+
+                object? v = test.GetProperty("ContractId")?.GetValue(dgvViewAll.CurrentItem, null);
+
+                if(v == null)
+                {
+                    LogManager.Fatal<FrmContractViewAll>("Unable to pull ContractId using Reflection!");
+                    return;
+                }
+
+                _selectedContract = _dbContext.Contracts.FirstOrDefault(c => c.ContractId == (int)v);
+            }
+        }
+
+        private void dgvViewAll_DataSourceChanged(object sender, Syncfusion.WinForms.DataGrid.Events.DataSourceChangedEventArgs e)
+        {
+            // hide non-default columns
+            if(dgvViewAll.Columns.Count == 0)
+            {
+                return;
+            }
+
+            dgvViewAll.Columns[nameof(Models.Contract.ContractId)].Visible = false;
+            dgvViewAll.Columns[nameof(Models.Contract.Description)].Visible = false;
+            dgvViewAll.Columns[nameof(Models.Contract.CreatedDate)].Visible = false;
+            dgvViewAll.Columns[nameof(Models.Contract.UpdatedDate)].Visible = false;
+            dgvViewAll.Columns[nameof(Models.Contract.UpdatedBy)].Visible = false;
+            dgvViewAll.Columns[nameof(Models.Contract.CreatedBy)].Visible = false;
+            dgvViewAll.Columns[nameof(Models.Contract.ComboDisplayName)].Visible = false;
+        }
+
     }
 }

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
@@ -69,6 +69,11 @@ namespace AssetTrakr.App.Forms.Contract
             dgvViewAll.Columns[nameof(Models.Contract.CreatedBy)].Visible = false;
             dgvViewAll.Columns[nameof(Models.Contract.ComboDisplayName)].Visible = false;
 
+            if (!_includeArchived)
+            {
+                dgvViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
+            }
+
             if (!contracts.Any())
             {
                 dgvViewAll.Visible = false;

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
@@ -243,48 +243,12 @@ namespace AssetTrakr.App.Forms.Contract
 
         private void dgvViewAll_SelectionChanged(object sender, Syncfusion.WinForms.DataGrid.Events.SelectionChangedEventArgs e)
         {
-            if (sfDgViewAll.CurrentItem != null)
-            {
-
-                var test = sfDgViewAll.CurrentItem.GetType();
-
-                object? v = test.GetProperty("ContractId")?.GetValue(sfDgViewAll.CurrentItem, null);
-
-                if(v == null)
-                {
-                    LogManager.Fatal<FrmContractViewAll>("Unable to pull ContractId using Reflection!");
-                    return;
-                }
-
-                _selectedContract = _dbContext.Contracts.FirstOrDefault(c => c.ContractId == (int)v);
-            }
+            _selectedContract = sfDgViewAll.GetCurrentItemProperty<Models.Contract>(nameof(Models.Contract.ContractId), _dbContext);
         }
 
         private void dgvViewAll_DataSourceChanged(object sender, Syncfusion.WinForms.DataGrid.Events.DataSourceChangedEventArgs e)
         {
-            // hide non-default columns
-            if(sfDgViewAll.Columns.Count == 0)
-            {
-                return;
-            }
-
-            // show the archive column if the system setting is enabled
-            if (_includeArchived)
-            {
-                sfDgViewAll.Columns[nameof(Models.Contract.IsArchived)].Visible = true;
-            }
-
-            // rename the columns to their respective DisplayName value from the model
-            // the efcore result is an anonymous object so we gotta do this
-            foreach(var column in sfDgViewAll.Columns)
-            {
-                // Get the property name from the column
-                string propertyName = column.MappingName;
-
-                // Set the header text of the column to the display name and column visibility
-                column.HeaderText = propertyName.GetPropertyDisplayName<Models.Contract>();
-                column.Visible = propertyName.GetPropertyVisibility<Models.Contract>();
-            }
+            sfDgViewAll.CustomColumnModifier<Models.Contract>(_includeArchived);
         }
 
     }

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
@@ -3,11 +3,13 @@ using AssetTrakr.App.Forms.Shared;
 using AssetTrakr.Database;
 using AssetTrakr.Extensions;
 using AssetTrakr.Logging;
+using AssetTrakr.Utils.Attributes;
 using AssetTrakr.Utils.Enums;
 using AssetTrakr.WinForms.ActionLog;
 using Microsoft.EntityFrameworkCore;
 using Syncfusion.Data.Extensions;
 using Syncfusion.WinForms.DataGrid;
+using System.ComponentModel.DataAnnotations;
 using System.Data;
 
 namespace AssetTrakr.App.Forms.Contract
@@ -105,7 +107,7 @@ namespace AssetTrakr.App.Forms.Contract
 
             foreach (var col in dgv.Columns)
             {
-                col.Visible = frmColumnSelector.SelectedColumns.Contains(col.MappingName);
+                col.Visible = frmColumnSelector.SelectedColumns.Contains(col.HeaderText);
             }
         }
 
@@ -266,19 +268,23 @@ namespace AssetTrakr.App.Forms.Contract
                 return;
             }
 
-            // hide the archive column if the system setting include archived is not enabled
-            if (!_includeArchived)
+            // show the archive column if the system setting is enabled
+            if (_includeArchived)
             {
-                sfDgViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
+                sfDgViewAll.Columns[nameof(Models.Contract.IsArchived)].Visible = true;
             }
 
-            sfDgViewAll.Columns[nameof(Models.Contract.ContractId)].Visible = false;
-            sfDgViewAll.Columns[nameof(Models.Contract.Description)].Visible = false;
-            sfDgViewAll.Columns[nameof(Models.Contract.CreatedDate)].Visible = false;
-            sfDgViewAll.Columns[nameof(Models.Contract.UpdatedDate)].Visible = false;
-            sfDgViewAll.Columns[nameof(Models.Contract.UpdatedBy)].Visible = false;
-            sfDgViewAll.Columns[nameof(Models.Contract.CreatedBy)].Visible = false;
-            sfDgViewAll.Columns[nameof(Models.Contract.ComboDisplayName)].Visible = false;
+            // rename the columns to their respective DisplayName value from the model
+            // the efcore result is an anonymous object so we gotta do this
+            foreach(var column in sfDgViewAll.Columns)
+            {
+                // Get the property name from the column
+                string propertyName = column.MappingName;
+
+                // Set the header text of the column to the display name and column visibility
+                column.HeaderText = propertyName.GetPropertyDisplayName<Models.Contract>();
+                column.Visible = propertyName.GetPropertyVisibility<Models.Contract>();
+            }
         }
 
     }

--- a/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
+++ b/AssetTrakr.App/Forms/Contract/FrmContractViewAll.cs
@@ -168,7 +168,7 @@ namespace AssetTrakr.App.Forms.Contract
                 catch (Exception ex)
                 {
                     MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Update Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    LogManager.Error<FrmAssetModify>($"{ex}");
+                    LogManager.Error<FrmContractViewAll>($"{ex}");
                 }
             }
         }
@@ -213,12 +213,12 @@ namespace AssetTrakr.App.Forms.Contract
             catch (DbUpdateException ex)
             {
                 MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Update Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogManager.Error<FrmAssetModify>($"{ex}");
+                LogManager.Error<FrmContractViewAll>($"{ex}");
             }
             catch (Exception ex)
             {
                 MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Unknown Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogManager.Error<FrmAssetModify>($"{ex}");
+                LogManager.Error<FrmContractViewAll>($"{ex}");
             }
         }
 

--- a/AssetTrakr.App/Forms/FrmMain.cs
+++ b/AssetTrakr.App/Forms/FrmMain.cs
@@ -59,15 +59,7 @@ namespace AssetTrakr.App.Forms
 
             Registration();
 
-            // backup the database if setting is enabled
-            if (_dbContext.SystemSettings.WhereEnabled(nameof(SystemSettings.AutomaticBackups)))
-            {
-                BackupManager backupManager = new(Convert.ToInt32(_dbContext.SystemSettings.FirstOrDefault(ss => ss.Name == nameof(SystemSettings.AutomaticBackups))?.SettingValue));
-                if (!backupManager.Backup())
-                {
-                    MessageBox.Show("Backup failed, see log for more details.", "Backup", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-            }
+            BackupDatabase();
 
             LoadWidgets();
 
@@ -83,6 +75,22 @@ namespace AssetTrakr.App.Forms
         private bool CanConnectDatabase()
         {
             return _dbContext.Database.CanConnect();
+        }
+
+        /// <summary>
+        /// Checks if <see cref="SystemSettings.AutomaticBackups"/> is true and backs up the database if so.
+        /// </summary>
+        private void BackupDatabase()
+        {
+            // backup the database if setting is enabled
+            if (_dbContext.SystemSettings.WhereEnabled(nameof(SystemSettings.AutomaticBackups)))
+            {
+                BackupManager backupManager = new(Convert.ToInt32(_dbContext.SystemSettings.FirstOrDefault(ss => ss.Name == nameof(SystemSettings.AutomaticBackups))?.SettingValue));
+                if (!backupManager.Backup())
+                {
+                    MessageBox.Show("Backup failed, see log for more details.", "Backup", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
         }
 
         /// <summary>
@@ -172,9 +180,6 @@ namespace AssetTrakr.App.Forms
         /// <summary>
         /// Creates the alerts for the AlertList for the User to view
         /// </summary>
-        /// <param name="isUpdateAvailable">
-        /// If true, the Update Available alert is included.
-        /// </param>
         private void RefreshAlerts()
         {
             AlertGenerator alertGenerator = new()

--- a/AssetTrakr.App/Forms/FrmMain.cs
+++ b/AssetTrakr.App/Forms/FrmMain.cs
@@ -20,6 +20,7 @@ namespace AssetTrakr.App.Forms
     {
 
         private DatabaseContext _dbContext;
+        private bool _isUpdateAvailable = false;
 
         public FrmMain()
         {
@@ -69,10 +70,12 @@ namespace AssetTrakr.App.Forms
             }
 
             LoadWidgets();
-            RefreshAlerts();
 
             CheckForUpdates checkForUpdates = new();
-            updateAvailableToolStripMenuItem.Visible = await checkForUpdates.UpdateAvailable(new Version(ProductVersion));
+            _isUpdateAvailable = await checkForUpdates.UpdateAvailable(new Version(ProductVersion));
+            updateAvailableToolStripMenuItem.Visible = _isUpdateAvailable;
+             
+            RefreshAlerts();
 
             aboutToolStripMenuItem.Text = $"About {ProductName}";
         }
@@ -169,9 +172,15 @@ namespace AssetTrakr.App.Forms
         /// <summary>
         /// Creates the alerts for the AlertList for the User to view
         /// </summary>
+        /// <param name="isUpdateAvailable">
+        /// If true, the Update Available alert is included.
+        /// </param>
         private void RefreshAlerts()
         {
-            AlertGenerator alertGenerator = new();
+            AlertGenerator alertGenerator = new()
+            {
+                IsUpdateAvailable = _isUpdateAvailable
+            };
 
             dgvAlerts.DataSource = alertGenerator.GetAlerts();
         }

--- a/AssetTrakr.App/Forms/License/FrmLicenseModify.cs
+++ b/AssetTrakr.App/Forms/License/FrmLicenseModify.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using AssetTrakr.Logging;
 using AssetTrakr.Utils.Enums;
 using AssetTrakr.WinForms.ActionLog;
+using AssetTrakr.Extensions;
 
 namespace AssetTrakr.App.Forms.License
 {
@@ -101,9 +102,8 @@ namespace AssetTrakr.App.Forms.License
 
         private void btnAddUpdate_Click(object sender, EventArgs e)
         {
-            if (txtName.Text.Length > 155 || txtName.Text.Length == 0)
+            if (txtName.IsRequired("Name", 155))
             {
-                MessageBox.Show("Name is a required field and must be be less than 156 characters", "Name", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/AssetTrakr.App/Forms/License/FrmLicenseViewAll.Designer.cs
+++ b/AssetTrakr.App/Forms/License/FrmLicenseViewAll.Designer.cs
@@ -40,11 +40,11 @@
             toolStripSeparator3 = new ToolStripSeparator();
             deleteToolStripMenuItem = new ToolStripMenuItem();
             archiveOrUnarchiveToolStripMenuItem = new ToolStripMenuItem();
-            dgvViewAll = new DataGridView();
             lblNoLicensesDescription = new Label();
             lblNoLicensesTitle = new Label();
+            sfDgViewAll = new Syncfusion.WinForms.DataGrid.SfDataGrid();
             cmsDgvRightClick.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)dgvViewAll).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)sfDgViewAll).BeginInit();
             SuspendLayout();
             // 
             // cmsDgvRightClick
@@ -112,32 +112,6 @@
             archiveOrUnarchiveToolStripMenuItem.Text = "Archive";
             archiveOrUnarchiveToolStripMenuItem.Click += archiveOrUnarchiveToolStripMenuItem_Click;
             // 
-            // dgvViewAll
-            // 
-            dgvViewAll.AllowUserToAddRows = false;
-            dgvViewAll.AllowUserToDeleteRows = false;
-            dgvViewAll.AllowUserToOrderColumns = true;
-            dgvViewAll.AllowUserToResizeRows = false;
-            dgvViewAll.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
-            dgvViewAll.BackgroundColor = Color.White;
-            dgvViewAll.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            dgvViewAll.ContextMenuStrip = cmsDgvRightClick;
-            dgvViewAll.Dock = DockStyle.Fill;
-            dgvViewAll.Location = new Point(0, 0);
-            dgvViewAll.MultiSelect = false;
-            dgvViewAll.Name = "dgvViewAll";
-            dgvViewAll.ReadOnly = true;
-            dgvViewAll.RowHeadersVisible = false;
-            dgvViewAll.RowHeadersWidth = 51;
-            dgvViewAll.RowHeadersWidthSizeMode = DataGridViewRowHeadersWidthSizeMode.DisableResizing;
-            dgvViewAll.SelectionMode = DataGridViewSelectionMode.FullRowSelect;
-            dgvViewAll.ShowCellErrors = false;
-            dgvViewAll.ShowCellToolTips = false;
-            dgvViewAll.ShowEditingIcon = false;
-            dgvViewAll.ShowRowErrors = false;
-            dgvViewAll.Size = new Size(1098, 661);
-            dgvViewAll.TabIndex = 18;
-            // 
             // lblNoLicensesDescription
             // 
             lblNoLicensesDescription.AutoSize = true;
@@ -159,23 +133,49 @@
             lblNoLicensesTitle.TabIndex = 22;
             lblNoLicensesTitle.Text = "No Licenses";
             // 
+            // sfDgViewAll
+            // 
+            sfDgViewAll.AccessibleName = "Table";
+            sfDgViewAll.AllowEditing = false;
+            sfDgViewAll.AllowFiltering = true;
+            sfDgViewAll.AutoSizeColumnsMode = Syncfusion.WinForms.DataGrid.Enums.AutoSizeColumnsMode.Fill;
+            sfDgViewAll.ContextMenuStrip = cmsDgvRightClick;
+            sfDgViewAll.Dock = DockStyle.Fill;
+            sfDgViewAll.Location = new Point(0, 0);
+            sfDgViewAll.Name = "sfDgViewAll";
+            sfDgViewAll.PreviewRowHeight = 35;
+            sfDgViewAll.ShowBusyIndicator = true;
+            sfDgViewAll.ShowGroupDropArea = true;
+            sfDgViewAll.ShowHeaderToolTip = true;
+            sfDgViewAll.Size = new Size(1098, 661);
+            sfDgViewAll.Style.BorderColor = Color.FromArgb(100, 100, 100);
+            sfDgViewAll.Style.CheckBoxStyle.CheckedBackColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.CheckBoxStyle.CheckedBorderColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.CheckBoxStyle.IndeterminateBorderColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.Style.HyperlinkStyle.DefaultLinkColor = Color.FromArgb(0, 120, 215);
+            sfDgViewAll.TabIndex = 28;
+            sfDgViewAll.Text = "sfDataGrid1";
+            sfDgViewAll.SelectionChanged += sfDgViewAll_SelectionChanged;
+            sfDgViewAll.DataSourceChanged += sfDgViewAll_DataSourceChanged;
+            // 
             // FrmLicenseViewAll
             // 
             AutoScaleDimensions = new SizeF(8F, 20F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = Color.White;
             ClientSize = new Size(1098, 661);
+            Controls.Add(sfDgViewAll);
             Controls.Add(lblNoLicensesDescription);
             Controls.Add(lblNoLicensesTitle);
-            Controls.Add(dgvViewAll);
-            FormBorderStyle = FormBorderStyle.FixedToolWindow;
+            FormBorderStyle = FormBorderStyle.FixedSingle;
             Icon = (Icon)resources.GetObject("$this.Icon");
+            MinimizeBox = false;
             MinimumSize = new Size(1116, 708);
             Name = "FrmLicenseViewAll";
             StartPosition = FormStartPosition.CenterParent;
             Text = "View All Licenses";
             cmsDgvRightClick.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)dgvViewAll).EndInit();
+            ((System.ComponentModel.ISupportInitialize)sfDgViewAll).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -183,7 +183,6 @@
         #endregion
         private ContextMenuStrip cmsDgvRightClick;
         private ToolStripMenuItem columnSelectorToolStripMenuItem;
-        private DataGridView dgvViewAll;
         private ToolStripSeparator toolStripSeparator1;
         private ToolStripMenuItem viewToolStripMenuItem;
         private ToolStripMenuItem editToolStripMenuItem;
@@ -194,5 +193,6 @@
         private ToolStripMenuItem deleteToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator3;
         private ToolStripMenuItem archiveOrUnarchiveToolStripMenuItem;
+        private Syncfusion.WinForms.DataGrid.SfDataGrid sfDgViewAll;
     }
 }

--- a/AssetTrakr.App/Forms/License/FrmLicenseViewAll.cs
+++ b/AssetTrakr.App/Forms/License/FrmLicenseViewAll.cs
@@ -108,6 +108,11 @@ namespace AssetTrakr.App.Forms.License
             dgvViewAll.Columns[nameof(Models.License.UpdatedBy)].Visible = false;
             dgvViewAll.Columns[nameof(Models.License.CreatedBy)].Visible = false;
 
+            if (!_includeArchived)
+            {
+                dgvViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
+            }
+
             if (!licenses.Any())
             {
                 dgvViewAll.Visible = false;

--- a/AssetTrakr.App/Forms/License/FrmLicenseViewAll.cs
+++ b/AssetTrakr.App/Forms/License/FrmLicenseViewAll.cs
@@ -1,11 +1,12 @@
-﻿using AssetTrakr.App.Forms.Asset;
-using AssetTrakr.App.Forms.Shared;
+﻿using AssetTrakr.App.Forms.Shared;
 using AssetTrakr.Database;
 using AssetTrakr.Extensions;
 using AssetTrakr.Logging;
 using AssetTrakr.Utils.Enums;
 using AssetTrakr.WinForms.ActionLog;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Bson;
+using Syncfusion.WinForms.DataGrid;
 using System.Data;
 
 namespace AssetTrakr.App.Forms.License
@@ -14,6 +15,8 @@ namespace AssetTrakr.App.Forms.License
     {
         private readonly DatabaseContext _dbContext;
         private readonly bool _includeArchived = false;
+        private Models.License? _selectedLicense;
+        private bool _firstLoad = true;
 
         public FrmLicenseViewAll()
         {
@@ -22,13 +25,17 @@ namespace AssetTrakr.App.Forms.License
             _dbContext ??= new DatabaseContext();
 
             _includeArchived = _dbContext.SystemSettings.WhereEnabled(nameof(SystemSettings.IncludeArchivedInViewAll));
+
+            Activated += AfterLoading;
         }
 
-        protected override void OnLoad(EventArgs e)
+        private async void AfterLoading(object? sender, EventArgs e)
         {
-            base.OnLoad(e);
-
-            LoadData();
+            if (_firstLoad)
+            {
+                await LoadData();
+                _firstLoad = false;
+            }
         }
 
         /// <summary>
@@ -37,21 +44,18 @@ namespace AssetTrakr.App.Forms.License
         /// <param name="needReload">
         /// True or false, true resets the datasource to NULL before loading data
         /// </param>
-        /// <param name="includeArchived">
-        /// True or False, true includes archived entities in the result
-        /// </param>
-        private void LoadData(bool needReload = false)
+        private async Task LoadData(bool needReload = false)
         {
             if (needReload)
             {
-                dgvViewAll.DataSource = null;
+                sfDgViewAll.DataSource = null;
             }
 
-            dgvViewAll.Visible = true;
+            sfDgViewAll.Visible = true;
             lblNoLicensesDescription.Visible = false;
             lblNoLicensesTitle.Visible = false;
 
-            var licenses = _dbContext.Licenses
+            var licenses = await _dbContext.Licenses
                 .Include(l => l.Manufacturer)
                 .Include(l => l.Contract)
                 .Include(l => l.Platform)
@@ -59,10 +63,10 @@ namespace AssetTrakr.App.Forms.License
                 {
                     l.Id,
                     l.Name,
+                    l.Purchased,
                     l.Count,
-                    l.PurchaseDate, // Purchase Date
-                    l.IsSubscription, // Subscription
-                    l.IsSubscriptionContract, // Subscription via Contract
+                    l.IsSubscription,
+                    l.IsSubscriptionContract,
                     Manufacturer = l.Manufacturer.Name ?? "",
                     Platform = l.Platform.Name ?? "",
                     Contract = l.Contract.Name ?? "",
@@ -80,42 +84,13 @@ namespace AssetTrakr.App.Forms.License
                     l.IsArchived
                 })
                 .Where(l => _includeArchived || !l.IsArchived)
-                .ToList();
+                .ToListAsync();
 
-            dgvViewAll.DataSource = licenses;
-
-            // Rename columns since it's an anonymous type and ignores [DisplayName] attribute in the License model
-            dgvViewAll.Columns[nameof(Models.License.PurchaseDate)].HeaderText = "Purchase Date";
-            dgvViewAll.Columns[nameof(Models.License.IsSubscription)].HeaderText = "Subscription";
-            dgvViewAll.Columns[nameof(Models.License.IsSubscriptionContract)].HeaderText = "Subscription via Contract";
-            dgvViewAll.Columns[nameof(Models.License.LicenseKey)].HeaderText = "License Key";
-            dgvViewAll.Columns[nameof(Models.License.OrderReference)].HeaderText = "Order Reference";
-            dgvViewAll.Columns[nameof(Models.License.RegisteredUser)].HeaderText = "User";
-            dgvViewAll.Columns[nameof(Models.License.RegisteredEmail)].HeaderText = "User Email";
-            dgvViewAll.Columns[nameof(Models.License.IsArchived)].HeaderText = "Archived";
-
-            // hide columns
-            dgvViewAll.Columns[nameof(Models.License.Id)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.Description)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.Version)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.LicenseKey)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.IsSubscriptionContract)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.OrderReference)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.RegisteredUser)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.RegisteredEmail)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.CreatedDate)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.UpdatedDate)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.UpdatedBy)].Visible = false;
-            dgvViewAll.Columns[nameof(Models.License.CreatedBy)].Visible = false;
-
-            if (!_includeArchived)
-            {
-                dgvViewAll.Columns[nameof(Models.Assets.Asset.IsArchived)].Visible = false;
-            }
+            sfDgViewAll.DataSource = licenses;
 
             if (!licenses.Any())
             {
-                dgvViewAll.Visible = false;
+                sfDgViewAll.Visible = false;
                 lblNoLicensesDescription.Visible = true;
                 lblNoLicensesTitle.Visible = true;
             }
@@ -123,95 +98,98 @@ namespace AssetTrakr.App.Forms.License
 
         private void columnSelectorToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (cmsDgvRightClick.SourceControl is not SfDataGrid dgv)
             {
                 return;
             }
 
-            FrmColumnSelector2 frmColumnSelector = new(dgv);
+            FrmColumnSelector2 frmColumnSelector = new(sfDgv: dgv);
             frmColumnSelector.ShowDialog();
 
-            foreach (DataGridViewColumn col in dgv.Columns)
+            foreach (var col in dgv.Columns)
             {
-                col.Visible = frmColumnSelector.SelectedColumns.Contains(col.Name);
+                col.Visible = frmColumnSelector.SelectedColumns.Contains(col.HeaderText);
             }
         }
 
         private void viewToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedLicense == null)
             {
+                MessageBox.Show("Unable to open license as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            FrmLicenseModify frmLicenseModify = new((int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[0].Value, true);
+            FrmLicenseModify frmLicenseModify = new(licenseId: _selectedLicense.Id, isReadOnly: true);
             frmLicenseModify.ShowDialog();
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedLicense == null)
             {
+                MessageBox.Show("Unable to open license as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            FrmLicenseModify frmLicenseModify = new((int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[0].Value);
+            FrmLicenseModify frmLicenseModify = new(licenseId: _selectedLicense.Id);
             frmLicenseModify.ShowDialog();
-            LoadData(true);
+            await LoadData(true);
         }
 
         private void exportToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            dgvViewAll.Export();
+            sfDgViewAll.Export();
         }
 
-        private void deleteToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void deleteToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedLicense == null)
             {
+                MessageBox.Show("Unable to open license as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            string name = (string)dgv.Rows[dgv.SelectedRows[0].Index].Cells["Name"].Value;
+            string name = _selectedLicense.Name;
             DialogResult dr = MessageBox.Show($"This action cannot be reversed, do you wish to delete {name}?", "Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
             if (dr == DialogResult.Yes)
             {
-                var licenseId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[0].Value;
+                var licenseId = _selectedLicense.Id;
 
                 try
                 {
-                    if (_dbContext.Licenses.Where(a => a.Id == licenseId).ExecuteDelete() > 0)
+                    if (_dbContext.Contracts.Where(a => a.ContractId == licenseId).ExecuteDelete() > 0)
                     {
                         ActionLogMethods.Deleted(_dbContext, ActionAlertCategory.License, name);
 
-                        LoadData(true);
+                        await LoadData(true);
                     }
                 }
                 catch (Exception ex)
                 {
                     MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Update Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    LogManager.Error<FrmAssetModify>($"{ex}");
+                    LogManager.Error<FrmLicenseViewAll>($"{ex}");
                 }
             }
         }
 
-        private void archiveOrUnarchiveToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void archiveOrUnarchiveToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedLicense == null)
             {
+                MessageBox.Show("Unable to open license as it is null.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             string? tooltipName = archiveOrUnarchiveToolStripMenuItem.Text;
 
-            string name = (string)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.Contract.Name)].Value;
+            string name = _selectedLicense.Name;
             DialogResult dr = MessageBox.Show($"Do you wish to {tooltipName} {name}?", "Warning", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
             if (dr != DialogResult.Yes) { return; }
 
-            var licenseId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.License.Id)].Value;
-            var license = _dbContext.Licenses.FirstOrDefault(a => a.Id == licenseId);
+            var license = _selectedLicense;
 
             if (license == null) { return; }
 
@@ -224,43 +202,54 @@ namespace AssetTrakr.App.Forms.License
 
                 if (tooltipName == "Archive")
                 {
-                    ActionLogMethods.Archived(_dbContext, ActionAlertCategory.Contract, name);
+                    ActionLogMethods.Archived(_dbContext, ActionAlertCategory.License, name);
                 }
                 else if (tooltipName == "Unarchive")
                 {
-                    ActionLogMethods.Unarchived(_dbContext, ActionAlertCategory.Contract, name);
+                    ActionLogMethods.Unarchived(_dbContext, ActionAlertCategory.License, name);
                 }
 
-                LoadData(true);
+                await LoadData(true);
             }
             catch (DbUpdateException ex)
             {
                 MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Update Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogManager.Error<FrmAssetModify>($"{ex}");
+                LogManager.Error<FrmLicenseViewAll>($"{ex}");
             }
             catch (Exception ex)
             {
                 MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Unknown Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogManager.Error<FrmAssetModify>($"{ex}");
+                LogManager.Error<FrmLicenseViewAll>($"{ex}");
             }
         }
 
         private void cmsDgvRightClick_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            // If the item is already in the archive, change the archive tool item to unarchive and disable editing
-            if (cmsDgvRightClick.SourceControl is not DataGridView dgv)
+            if (_selectedLicense == null)
             {
+                cmsDgvRightClick.HideItems();
                 return;
             }
+            cmsDgvRightClick.ShowItems();
 
-            var licenseId = (int)dgv.Rows[dgv.SelectedRows[0].Index].Cells[nameof(Models.License.Id)].Value;
-            var license = _dbContext.Licenses.FirstOrDefault(l => l.Id == licenseId);
+            // If the item is already in the archive, change the archive tool item to unarchive and disable editing
+            var license = _selectedLicense;
 
             if (license == null) { return; }
 
             editToolStripMenuItem.Enabled = editToolStripMenuItem.Visible = !license.IsArchived;
             archiveOrUnarchiveToolStripMenuItem.Text = license.IsArchived ? "Unarchive" : "Archive";
 
+        }
+
+        private void sfDgViewAll_SelectionChanged(object sender, Syncfusion.WinForms.DataGrid.Events.SelectionChangedEventArgs e)
+        {
+            _selectedLicense = sfDgViewAll.GetCurrentItemProperty<Models.License>(nameof(Models.License.Id), _dbContext);
+        }
+
+        private void sfDgViewAll_DataSourceChanged(object sender, Syncfusion.WinForms.DataGrid.Events.DataSourceChangedEventArgs e)
+        {
+            sfDgViewAll.CustomColumnModifier<Models.License>(_includeArchived);
         }
     }
 }

--- a/AssetTrakr.App/Forms/Miscellaneous/FrmAbout.cs
+++ b/AssetTrakr.App/Forms/Miscellaneous/FrmAbout.cs
@@ -11,7 +11,7 @@ namespace AssetTrakr.App.Forms.Miscellaneous
         {
             InitializeComponent();
             Text = $"About {AssemblyTitle}";
-            lblProductName.Text = $"Product: {AssemblyProduct}";
+            lblProductName.Text = $"{AssemblyProduct}";
             lblVersionValue.Text = $"Version: v{AssemblyVersion}";
             lblCopyrightValue.Text = $"Copyright (c) {AssemblyCopyright}";
             lblDescriptionValue.Text = $"AssetTrakr is a License, Contract and Asset Tracker for home use built using EF Core and .NET 8.";

--- a/AssetTrakr.App/Forms/Miscellaneous/FrmSystemSettings.Designer.cs
+++ b/AssetTrakr.App/Forms/Miscellaneous/FrmSystemSettings.Designer.cs
@@ -63,6 +63,7 @@
             dgvSystemSettings.RowHeadersWidth = 51;
             dgvSystemSettings.Size = new Size(1010, 435);
             dgvSystemSettings.TabIndex = 0;
+            dgvSystemSettings.CellValueChanged += dgvSystemSettings_CellValueChanged;
             // 
             // dataGridViewTextBoxColumn1
             // 

--- a/AssetTrakr.App/Forms/Miscellaneous/FrmSystemSettings.Designer.cs
+++ b/AssetTrakr.App/Forms/Miscellaneous/FrmSystemSettings.Designer.cs
@@ -51,13 +51,13 @@
             // 
             dgvSystemSettings.AllowUserToAddRows = false;
             dgvSystemSettings.AllowUserToDeleteRows = false;
+            dgvSystemSettings.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             dgvSystemSettings.AutoGenerateColumns = false;
             dgvSystemSettings.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells;
             dgvSystemSettings.BackgroundColor = Color.White;
             dgvSystemSettings.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             dgvSystemSettings.Columns.AddRange(new DataGridViewColumn[] { dataGridViewTextBoxColumn1, dataGridViewTextBoxColumn2, categoryDataGridViewTextBoxColumn, settingParentTypeDataGridViewTextBoxColumn, dataGridViewCheckBoxColumn1, dataGridViewCheckBoxColumn2, settingValueDataGridViewTextBoxColumn, defaultSettingValueDataGridViewTextBoxColumn });
             dgvSystemSettings.DataSource = systemSettingBindingSource;
-            dgvSystemSettings.Dock = DockStyle.Bottom;
             dgvSystemSettings.Location = new Point(0, 56);
             dgvSystemSettings.Name = "dgvSystemSettings";
             dgvSystemSettings.RowHeadersWidth = 51;

--- a/AssetTrakr.App/Forms/Miscellaneous/FrmSystemSettings.cs
+++ b/AssetTrakr.App/Forms/Miscellaneous/FrmSystemSettings.cs
@@ -27,6 +27,7 @@ namespace AssetTrakr.App.Forms.Miscellaneous
             cmbCategory.DataSource = _dbContext.SystemSettings.GroupBy(a => a.Category).Select(x => x.First()).ToList();
             cmbCategory.DisplayMember = "Category";
             cmbCategory.ValueMember = "Category";
+
         }
 
         private void btnSave_Click(object sender, EventArgs e)
@@ -56,17 +57,17 @@ namespace AssetTrakr.App.Forms.Miscellaneous
 
             if (sender is ComboBox cmb && cmb.SelectedItem != null)
             {
-                if(cmb.SelectedItem != null)
+                if (cmb.SelectedItem != null)
                 {
                     var temp = (SystemSetting)cmb.SelectedItem;
 
                     _category = temp.Category;
                 }
-     
+
             }
 
             _dbContext = new();
-            
+
             // need to load the data before binding it otherwise it never appears lol
             _dbContext.SystemSettings.Where(c => c.Category == _category).Load();
 
@@ -87,6 +88,28 @@ namespace AssetTrakr.App.Forms.Miscellaneous
                     return;
             }
             dgvSystemSettings.Columns["settingValueDataGridViewTextBoxColumn"].Visible = true;
+        }
+
+        private void dgvSystemSettings_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex == -1 || !dgvSystemSettings.Columns[e.ColumnIndex].Name.Equals($"{nameof(SystemSetting.SettingValue)}DataGridViewTextBoxColumn", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return;
+            }
+
+            int row = e.RowIndex;
+            string settingName = (string)dgvSystemSettings.Rows[row].Cells[0].Value;
+            var modifiedCell = dgvSystemSettings.Rows[row].Cells[e.ColumnIndex];
+
+            if (settingName == nameof(SystemSettings.CheckForUpdates))
+            {
+                List<string> options = ["stable", "beta"];
+                if (!options.Contains(modifiedCell.Value))
+                {
+                    modifiedCell.Value = options[0];
+                    MessageBox.Show($"Invalid setting value for {settingName}, please use one of the supported values:\r\n\r\n{string.Join(", ", options)}", "Invalid Value", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
         }
     }
 }

--- a/AssetTrakr.App/Forms/Shared/FrmColumnSelector2.cs
+++ b/AssetTrakr.App/Forms/Shared/FrmColumnSelector2.cs
@@ -1,4 +1,6 @@
 ﻿
+using Syncfusion.WinForms.DataGrid;
+
 namespace AssetTrakr.App.Forms.Shared
 {
     public partial class FrmColumnSelector2 : Form
@@ -6,24 +8,24 @@ namespace AssetTrakr.App.Forms.Shared
         public List<string> AvailableColumns = [];
         public List<string> SelectedColumns = [];
 
-        public FrmColumnSelector2(DataGridView dgv)
+        public FrmColumnSelector2(DataGridView? dgv2 = null, SfDataGrid? sfDgv = null)
         {
             InitializeComponent();
 
-            if(dgv == null)
+            if(sfDgv == null)
             {
-                throw new ArgumentOutOfRangeException(nameof(dgv), "DataGridView has not been passed to form");
+                throw new ArgumentOutOfRangeException(nameof(sfDgv), "Data Grid has not been passed to form");
             }
 
-            foreach (DataGridViewColumn col in dgv.Columns)
+            foreach (var col in sfDgv.Columns)
             {
                 if (col.Visible)
                 {
-                    SelectedColumns.Add(col.Name);
+                    SelectedColumns.Add(col.MappingName);
                 }
                 else
                 {
-                    AvailableColumns.Add(col.Name);
+                    AvailableColumns.Add(col.MappingName);
                 }
             }
         }

--- a/AssetTrakr.App/Forms/Shared/FrmColumnSelector2.cs
+++ b/AssetTrakr.App/Forms/Shared/FrmColumnSelector2.cs
@@ -18,11 +18,11 @@ namespace AssetTrakr.App.Forms.Shared
                 {
                     if (col.Visible)
                     {
-                        SelectedColumns.Add(col.MappingName);
+                        SelectedColumns.Add(col.HeaderText);
                     }
                     else
                     {
-                        AvailableColumns.Add(col.MappingName);
+                        AvailableColumns.Add(col.HeaderText);
                     }
                 }
             }

--- a/AssetTrakr.App/Forms/Shared/FrmColumnSelector2.cs
+++ b/AssetTrakr.App/Forms/Shared/FrmColumnSelector2.cs
@@ -12,21 +12,36 @@ namespace AssetTrakr.App.Forms.Shared
         {
             InitializeComponent();
 
-            if(sfDgv == null)
+            if(sfDgv != null)
             {
-                throw new ArgumentOutOfRangeException(nameof(sfDgv), "Data Grid has not been passed to form");
+                foreach (var col in sfDgv.Columns)
+                {
+                    if (col.Visible)
+                    {
+                        SelectedColumns.Add(col.MappingName);
+                    }
+                    else
+                    {
+                        AvailableColumns.Add(col.MappingName);
+                    }
+                }
             }
-
-            foreach (var col in sfDgv.Columns)
+            else if(dgv2 != null)
             {
-                if (col.Visible)
+                foreach (DataGridViewColumn col in dgv2.Columns)
                 {
-                    SelectedColumns.Add(col.MappingName);
+                    if (col.Visible)
+                    {
+                        SelectedColumns.Add(col.Name);
+                    }
+                    else
+                    {
+                        AvailableColumns.Add(col.Name);
+                    }
                 }
-                else
-                {
-                    AvailableColumns.Add(col.MappingName);
-                }
+            } else
+            {
+                throw new Exception($"{nameof(dgv2)} and {nameof(sfDgv)} are null!  At least one is required!");
             }
         }
 

--- a/AssetTrakr.App/Program.cs
+++ b/AssetTrakr.App/Program.cs
@@ -18,11 +18,14 @@ namespace AssetTrakr.App
             ApplicationConfiguration.Initialize();
 
             LogManager logManager = new();
-            LogManager.Information("Initialize...");
+            LogManager.Information("Initialize...", nameof(Program));
 
 #if DEBUG
-            LogManager.Information("APPLICATION IS IN DEBUG MODE");
+            LogManager.Information("APPLICATION IS IN DEBUG MODE", nameof(Program));
 #endif
+
+            LogManager.Debug("Registering SyncFusion", nameof(Program));
+            Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("%SFLIC%");
 
             ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
 

--- a/AssetTrakr.App/Program.cs
+++ b/AssetTrakr.App/Program.cs
@@ -38,8 +38,6 @@ namespace AssetTrakr.App
             CreateDirectories();
 
             Application.Run(new Forms.FrmMain());
-
-            LogManager.Information("Application started", typeof(Program));
         }
 
         /// <summary>

--- a/AssetTrakr.App/Program.cs
+++ b/AssetTrakr.App/Program.cs
@@ -1,7 +1,8 @@
 using AssetTrakr.Database;
+using AssetTrakr.Extensions;
 using AssetTrakr.Logging;
 using OfficeOpenXml;
-using Serilog;
+using Syncfusion.Licensing;
 
 namespace AssetTrakr.App
 {
@@ -18,18 +19,35 @@ namespace AssetTrakr.App
             ApplicationConfiguration.Initialize();
 
             LogManager logManager = new();
-            LogManager.Information("Initialize...", nameof(Program));
+            LogManager.Information("Initialize...", typeof(Program));
 
 #if DEBUG
-            LogManager.Information("APPLICATION IS IN DEBUG MODE", nameof(Program));
+            LogManager.Information("APPLICATION IS IN DEBUG MODE", typeof(Program));
 #endif
 
-            LogManager.Information("Registering SyncFusion", nameof(Program));
+            LogManager.Information("Registering Syncfusion with Community License!", typeof(Program));
 
-            Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense(SyncfusionInfo.LicenseKey);
+            // SyncfusionInfo is generated during the build process.  If "GeneratedSyncfusionLicense.cs" does not exist in the AssetTrakr
+            // project yet, ensure you build per https://github.com/McKenzie-Software/AssetTrakr/wiki/Build-from-Source#107-onwards
+            SyncfusionLicenseProvider.RegisterLicense(SyncfusionInfo.LicenseKey);
+            bool sfLicenseStatus = SyncfusionLicenseProvider.ValidateLicense(Platform.WindowsForms, out var sfLicenseStatusMsg);
 
-            LogManager.Information("Registering EPPlus LicenseContext", nameof(Program));
+            if (SyncfusionInfo.LicenseKey == "nullkey")
+            {
+                LogManager.Fatal("SyncfusionInfo.LicenseKey is set to nullkey, a validate Sf License must be provided during build! see " +
+                    "https://github.com/McKenzie-Software/AssetTrakr/wiki/Build-from-Source#107-onwards", typeof(Program));
+            }
 
+            if (string.IsNullOrEmpty(sfLicenseStatusMsg))
+            {
+                LogManager.Information($"Syncfusion License Valid: {sfLicenseStatus}", typeof(Program));
+            } 
+            else
+            {
+                LogManager.Information($"Syncfusion Validate License Response: {sfLicenseStatusMsg}", typeof(Program));
+            }
+
+            LogManager.Information("Registering EPPlus LicenseContext", typeof(Program));
             ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
 
             CreateDirectories();

--- a/AssetTrakr.App/Program.cs
+++ b/AssetTrakr.App/Program.cs
@@ -24,8 +24,11 @@ namespace AssetTrakr.App
             LogManager.Information("APPLICATION IS IN DEBUG MODE", nameof(Program));
 #endif
 
-            LogManager.Debug("Registering SyncFusion", nameof(Program));
-            Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense("%SFLIC%");
+            LogManager.Information("Registering SyncFusion", nameof(Program));
+
+            Syncfusion.Licensing.SyncfusionLicenseProvider.RegisterLicense(SyncfusionInfo.LicenseKey);
+
+            LogManager.Information("Registering EPPlus LicenseContext", nameof(Program));
 
             ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
 

--- a/AssetTrakr.App/Program.cs
+++ b/AssetTrakr.App/Program.cs
@@ -3,9 +3,12 @@ using AssetTrakr.Extensions;
 using AssetTrakr.Logging;
 using OfficeOpenXml;
 using Syncfusion.Licensing;
+using Syncfusion.PdfViewer.Base;
+using System.Runtime.Versioning;
 
 namespace AssetTrakr.App
 {
+    [SupportedOSPlatform("windows")]
     internal static class Program
     {
         /// <summary>
@@ -19,12 +22,48 @@ namespace AssetTrakr.App
             ApplicationConfiguration.Initialize();
 
             LogManager logManager = new();
-            LogManager.Information("Initialize...", typeof(Program));
+            LogManager.Information("Application Startup in progress...", typeof(Program));
 
 #if DEBUG
-            LogManager.Information("APPLICATION IS IN DEBUG MODE", typeof(Program));
+            LogManager.Information("Build config: debug", typeof(Program));
+#else
+            LogManager.Information("Build config: release", typeof(Program));
 #endif
 
+            SyncfusionLicenseValidation();
+            
+            LogManager.Information("Registering EPPlus LicenseContext", typeof(Program));
+            ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+            CreateDirectories();
+
+            Application.Run(new Forms.FrmMain());
+
+            LogManager.Information("Application started", typeof(Program));
+        }
+
+        /// <summary>
+        /// Creates the Database Directories, see <see cref="DatabaseSettings"/>
+        /// </summary>
+        private static void CreateDirectories()
+        {
+            if (!Directory.Exists(DatabaseSettings.directoryPath))
+            {
+                Directory.CreateDirectory(DatabaseSettings.directoryPath);
+            }
+
+            if (!Directory.Exists(DatabaseSettings.directoryBackupPath))
+            {
+                Directory.CreateDirectory(DatabaseSettings.directoryBackupPath);
+            }
+        }
+
+        /// <summary>
+        /// Registers the Syncfusion License as well as checking if it is a valid license.  An invalid license does not prevent the program working
+        /// however will show syncfusion forced pop-ups in-app and watermarks in exports.
+        /// </summary>
+        private static void SyncfusionLicenseValidation()
+        {
             LogManager.Information("Registering Syncfusion with Community License!", typeof(Program));
 
             // SyncfusionInfo is generated during the build process.  If "GeneratedSyncfusionLicense.cs" does not exist in the AssetTrakr
@@ -41,30 +80,10 @@ namespace AssetTrakr.App
             if (string.IsNullOrEmpty(sfLicenseStatusMsg))
             {
                 LogManager.Information($"Syncfusion License Valid: {sfLicenseStatus}", typeof(Program));
-            } 
+            }
             else
             {
                 LogManager.Information($"Syncfusion Validate License Response: {sfLicenseStatusMsg}", typeof(Program));
-            }
-
-            LogManager.Information("Registering EPPlus LicenseContext", typeof(Program));
-            ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
-
-            CreateDirectories();
-
-            Application.Run(new Forms.FrmMain());
-        }
-
-        private static void CreateDirectories()
-        {
-            if (!Directory.Exists(DatabaseSettings.directoryPath))
-            {
-                Directory.CreateDirectory(DatabaseSettings.directoryPath);
-            }
-
-            if (!Directory.Exists(DatabaseSettings.directoryBackupPath))
-            {
-                Directory.CreateDirectory(DatabaseSettings.directoryBackupPath);
             }
         }
     }

--- a/AssetTrakr.Database/AssetTrakr.Database.csproj
+++ b/AssetTrakr.Database/AssetTrakr.Database.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PlatformTarget>x64</PlatformTarget>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Database/DatabaseSettings.cs
+++ b/AssetTrakr.Database/DatabaseSettings.cs
@@ -37,6 +37,6 @@
         /// The full path including the database name.  Backups have DateTime.Now() appended AFTER the extension
         /// C:\ProgramData\Laim\AssetTrakr\Database\{databaseName}.db-ddmmyyyhhmmss
         /// </summary>
-        public static string databaseFileBackupPath = Path.Combine(directoryBackupPath, $"{databaseFileName}-{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}");
+        public static string databaseFileBackupPath = Path.Combine(directoryBackupPath, $"{DateTimeOffset.UtcNow:yyyyMMddTHHmmss.fffZ}_{databaseFileName}");
     }
 }

--- a/AssetTrakr.Database/Migrations/20240615170647_LicenseModelChange107.Designer.cs
+++ b/AssetTrakr.Database/Migrations/20240615170647_LicenseModelChange107.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AssetTrakr.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AssetTrakr.Database.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20240615170647_LicenseModelChange107")]
+    partial class LicenseModelChange107
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.2");

--- a/AssetTrakr.Database/Migrations/20240615170647_LicenseModelChange107.cs
+++ b/AssetTrakr.Database/Migrations/20240615170647_LicenseModelChange107.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AssetTrakr.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class LicenseModelChange107 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "RegisteredUser",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RegisteredEmail",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OrderReference",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LicenseKey",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "RegisteredUser",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RegisteredEmail",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OrderReference",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LicenseKey",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Licenses",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+        }
+    }
+}

--- a/AssetTrakr.Extensions/AssetTrakr.Extensions.csproj
+++ b/AssetTrakr.Extensions/AssetTrakr.Extensions.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="7.1.2" />
+    <PackageReference Include="Syncfusion.Core.WinForms" Version="25.2.4" />
+    <PackageReference Include="Syncfusion.DataGridExport.WinForms" Version="25.2.4" />
+    <PackageReference Include="Syncfusion.SfDataGrid.WinForms" Version="25.2.4" />
+    <PackageReference Include="Syncfusion.XlsIO.WinForms" Version="25.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Extensions/AssetTrakr.Extensions.csproj
+++ b/AssetTrakr.Extensions/AssetTrakr.Extensions.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\AssetTrakr.Database\AssetTrakr.Database.csproj" />
     <ProjectReference Include="..\AssetTrakr.Logging\AssetTrakr.Logging.csproj" />
     <ProjectReference Include="..\AssetTrakr.Models\AssetTrakr.Models.csproj" />
   </ItemGroup>

--- a/AssetTrakr.Extensions/AssetTrakr.Extensions.csproj
+++ b/AssetTrakr.Extensions/AssetTrakr.Extensions.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="7.1.2" />
-    <PackageReference Include="Syncfusion.Core.WinForms" Version="25.2.4" />
-    <PackageReference Include="Syncfusion.DataGridExport.WinForms" Version="25.2.4" />
-    <PackageReference Include="Syncfusion.SfDataGrid.WinForms" Version="25.2.4" />
-    <PackageReference Include="Syncfusion.XlsIO.WinForms" Version="25.2.4" />
+    <PackageReference Include="Syncfusion.Core.WinForms" Version="26.1.35" />
+    <PackageReference Include="Syncfusion.DataGridExport.WinForms" Version="26.1.35" />
+    <PackageReference Include="Syncfusion.SfDataGrid.WinForms" Version="26.1.35" />
+    <PackageReference Include="Syncfusion.XlsIO.WinForms" Version="26.1.35" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Extensions/AssetTrakr.Extensions.csproj
+++ b/AssetTrakr.Extensions/AssetTrakr.Extensions.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Extensions/ContextMenuStripExtensions.cs
+++ b/AssetTrakr.Extensions/ContextMenuStripExtensions.cs
@@ -1,0 +1,41 @@
+﻿namespace AssetTrakr.Extensions
+{
+    public static class ContextMenuStripExtensions
+    {
+
+        /// <summary>
+        /// Hides all items in the ContextMenuStrip starting from the choosen startIndex
+        /// </summary>
+        /// <param name="cms">
+        /// The ContextMenuStrip you want to modify
+        /// </param>
+        /// <param name="startIndex">
+        /// The index within <see cref="ContextMenuStrip"/> Items that you want to hide
+        /// </param>
+        public static void HideItems(this ContextMenuStrip cms, int startIndex = 3)
+        {
+            for (int i = startIndex; i < cms.Items.Count; i++) // Start from index 1 to skip the first item
+            {
+                // Set the Visible property to false for each item except the first one
+                cms.Items[i].Visible = false;
+            }
+        }
+
+        /// <summary>
+        /// Shows all items in the ContextMenuStrip starting from the choosen startIndex
+        /// </summary>
+        /// <param name="cms">
+        /// The ContextMenuStrip you want to modify
+        /// </param>
+        /// <param name="startIndex">
+        /// The index within <see cref="ContextMenuStrip"/> Items that you want to show
+        /// </param>
+        public static void ShowItems(this ContextMenuStrip cms, int startIndex = 3)
+        {
+            for(int i = startIndex; i < cms.Items.Count; i++)
+            {
+                cms.Items[i].Visible = true;
+            }
+        }
+    }
+}

--- a/AssetTrakr.Extensions/DataGridViewExtensions.cs
+++ b/AssetTrakr.Extensions/DataGridViewExtensions.cs
@@ -1,9 +1,13 @@
-﻿using AssetTrakr.Logging;
+﻿using AssetTrakr.Database;
+using AssetTrakr.Logging;
+using Microsoft.EntityFrameworkCore;
 using OfficeOpenXml;
+using SQLitePCL;
 using Syncfusion.WinForms.DataGrid;
 using Syncfusion.XlsIO;
 using System.Data;
 using System.Runtime.Versioning;
+using System.Windows.Forms;
 
 namespace AssetTrakr.Extensions
 {
@@ -147,6 +151,82 @@ namespace AssetTrakr.Extensions
             {
                 MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 LogManager.Error($"{ex}", typeof(DataGridViewExtensions));
+            }
+        }
+
+        /// <summary>
+        /// Get's a property from the CurrentItem's model using .CurrentItem.GetType()
+        /// </summary>
+        /// <param name="sfDataGrid">
+        /// The current <see cref="SfDataGrid"/>
+        /// </param>
+        public static T? GetCurrentItemProperty<T>(this SfDataGrid sfDataGrid, string propertyName, DatabaseContext dbContext) where T : class
+        {
+            if (sfDataGrid.CurrentItem == null)
+            {
+                LogManager.Fatal("Unable to pull property using Reflection! CurrentItem is null.", typeof(DataGridViewExtensions));
+                return null;
+            }
+
+            var type = sfDataGrid.CurrentItem.GetType();
+
+            object? propertyValue = type.GetProperty(propertyName)?.GetValue(sfDataGrid.CurrentItem, null);
+
+            if(propertyValue == null)
+            {
+                LogManager.Fatal($"Unable to pull {propertyName} using Reflection!", typeof(DataGridViewExtensions));
+                return null;
+            }
+
+            return dbContext.Set<T>().FirstOrDefault(e => EF.Property<object>(e, propertyName).Equals(propertyValue));
+
+        }
+
+        /// <summary>
+        /// Loops through the <see cref="SfDataGrid"/> and changes the column header text using <see cref="StringToPropertyExtensions.GetPropertyDisplayName{T}(string)"/>
+        /// and the column visibility using <see cref="StringToPropertyExtensions.GetPropertyVisibility{T}(string)"/>.  Also changes the Archived column visibility
+        /// based on <paramref name="includeArchived"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The base model for DataGrid
+        /// </typeparam>
+        /// <param name="sfDataGrid">
+        /// The current <see cref="SfDataGrid"/>
+        /// </param>
+        /// <param name="includeArchived">
+        /// User System Setting which is true or false for including archived items in the sfDataGrid or not
+        /// </param>
+        public static void CustomColumnModifier<T>(this SfDataGrid sfDataGrid, bool includeArchived) where T : class
+        {
+            // hide non-default columns
+            if (sfDataGrid.Columns.Count == 0)
+            {
+                return;
+            }
+
+            // show the archive column if the system setting is enabled
+            if (includeArchived)
+            {
+                try
+                {
+                    sfDataGrid.Columns["IsArchived"].Visible = true;
+                } catch
+                {
+                    LogManager.Fatal($"Unable to modify IsArchived visibility, is the column name correct in {typeof(T)}?", typeof(DataGridViewExtensions));
+                }
+            }
+
+            // rename the columns to their respective DisplayName value from the model
+            // the efcore result is an anonymous object so we gotta do this
+            foreach (var column in sfDataGrid.Columns)
+            {
+                // Get the property name from the column
+                string propertyName = column.MappingName;
+
+
+                // Set the header text of the column to the display name and column visibility
+                column.HeaderText = propertyName.GetPropertyDisplayName<T>();
+                column.Visible = propertyName.GetPropertyVisibility<T>();
             }
         }
     }

--- a/AssetTrakr.Extensions/DataGridViewExtensions.cs
+++ b/AssetTrakr.Extensions/DataGridViewExtensions.cs
@@ -7,7 +7,6 @@ using Syncfusion.WinForms.DataGrid;
 using Syncfusion.XlsIO;
 using System.Data;
 using System.Runtime.Versioning;
-using System.Windows.Forms;
 
 namespace AssetTrakr.Extensions
 {
@@ -32,7 +31,7 @@ namespace AssetTrakr.Extensions
 
             if (saveFileDialog.ShowDialog() != DialogResult.OK)
             {
-                MessageBox.Show("Export Cancelled", "Cancelled", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                //MessageBox.Show("Export Cancelled", "Cancelled", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 
@@ -95,7 +94,7 @@ namespace AssetTrakr.Extensions
 
             if (saveFileDialog.ShowDialog() != DialogResult.OK)
             {
-                MessageBox.Show("Export Cancelled", "Cancelled", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                //MessageBox.Show("Export Cancelled", "Cancelled", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 

--- a/AssetTrakr.Extensions/DataGridViewExtensions.cs
+++ b/AssetTrakr.Extensions/DataGridViewExtensions.cs
@@ -97,7 +97,7 @@ namespace AssetTrakr.Extensions
 
             try
             {
-                using (ExcelEngine excelEngine = new ExcelEngine())
+                using (ExcelEngine excelEngine = new())
                 {
                     IWorkbook workbook = excelEngine.Excel.Workbooks.Create();
                     IWorksheet worksheet = workbook.Worksheets[0];

--- a/AssetTrakr.Extensions/DataGridViewExtensions.cs
+++ b/AssetTrakr.Extensions/DataGridViewExtensions.cs
@@ -204,18 +204,6 @@ namespace AssetTrakr.Extensions
                 return;
             }
 
-            // show the archive column if the system setting is enabled
-            if (includeArchived)
-            {
-                try
-                {
-                    sfDataGrid.Columns["IsArchived"].Visible = true;
-                } catch
-                {
-                    LogManager.Fatal($"Unable to modify IsArchived visibility, is the column name correct in {typeof(T)}?", typeof(DataGridViewExtensions));
-                }
-            }
-
             // rename the columns to their respective DisplayName value from the model
             // the efcore result is an anonymous object so we gotta do this
             foreach (var column in sfDataGrid.Columns)
@@ -227,6 +215,19 @@ namespace AssetTrakr.Extensions
                 // Set the header text of the column to the display name and column visibility
                 column.HeaderText = propertyName.GetPropertyDisplayName<T>();
                 column.Visible = propertyName.GetPropertyVisibility<T>();
+            }
+
+            // show the archive column if the system setting is enabled
+            if (includeArchived)
+            {
+                try
+                {
+                    sfDataGrid.Columns["IsArchived"].Visible = true;
+                }
+                catch
+                {
+                    LogManager.Fatal($"Unable to modify IsArchived visibility, is the column name correct in {typeof(T)}?", typeof(DataGridViewExtensions));
+                }
             }
         }
     }

--- a/AssetTrakr.Extensions/DataGridViewExtensions.cs
+++ b/AssetTrakr.Extensions/DataGridViewExtensions.cs
@@ -3,9 +3,11 @@ using OfficeOpenXml;
 using Syncfusion.WinForms.DataGrid;
 using Syncfusion.XlsIO;
 using System.Data;
+using System.Runtime.Versioning;
 
 namespace AssetTrakr.Extensions
 {
+    [SupportedOSPlatform("windows")]
     public static class DataGridViewExtensions
     {
         /// <summary>

--- a/AssetTrakr.Extensions/DataGridViewExtensions.cs
+++ b/AssetTrakr.Extensions/DataGridViewExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using AssetTrakr.Logging;
 using OfficeOpenXml;
+using Syncfusion.WinForms.DataGrid;
+using Syncfusion.XlsIO;
+using System.Data;
 
 namespace AssetTrakr.Extensions
 {
@@ -21,45 +24,128 @@ namespace AssetTrakr.Extensions
                 FileName = $"{Guid.NewGuid()}.xlsx"
             };
 
-            if (saveFileDialog.ShowDialog() == DialogResult.OK)
+            if (saveFileDialog.ShowDialog() != DialogResult.OK)
             {
-                try
-                {
-                    using var package = new ExcelPackage(new FileInfo(saveFileDialog.FileName));
-                    var worksheet = package.Workbook.Worksheets.Add("Report");
+                MessageBox.Show("Export Cancelled", "Cancelled", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
 
-                    // Get visible columns in the current display order
-                    var visibleColumns = dgv.Columns.Cast<DataGridViewColumn>()
-                        .Where(c => c.Visible)
-                        .OrderBy(c => c.DisplayIndex);
+            try
+            {
+                using var package = new ExcelPackage(new FileInfo(saveFileDialog.FileName));
+                var worksheet = package.Workbook.Worksheets.Add("Report");
+
+                // Get visible columns in the current display order
+                var visibleColumns = dgv.Columns.Cast<DataGridViewColumn>()
+                    .Where(c => c.Visible)
+                    .OrderBy(c => c.DisplayIndex);
+
+                // Write column headers
+                int columnIndex = 1;
+                foreach (var column in visibleColumns)
+                {
+                    worksheet.Cells[1, columnIndex].Value = column.HeaderText;
+                    columnIndex++;
+                }
+
+                // Write data
+                for (int i = 0; i < dgv.Rows.Count; i++)
+                {
+                    int cellIndex = 1;
+                    foreach (var column in visibleColumns)
+                    {
+                        worksheet.Cells[i + 2, cellIndex].Value = dgv.Rows[i].Cells[column.Index].Value;
+                        cellIndex++;
+                    }
+                }
+
+                package.Save();
+
+                MessageBox.Show($"Export saved to {saveFileDialog.FileName}", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                LogManager.Error($"{ex}", nameof(DataGridViewExtensions));
+            }
+
+        }
+
+        /// <summary>
+        /// Exports current SfDataGrid visible contents to .xlsx using <see cref="ExcelEngine"/>
+        /// </summary>
+        /// <param name="sfDataGrid">
+        /// The current <see cref="SfDataGrid"/>
+        /// </param>
+        public static void Export(this SfDataGrid sfDataGrid)
+        {
+            SaveFileDialog saveFileDialog = new()
+            {
+                AddExtension = true,
+                Filter = "Excel Files|*.xlsx",
+                Title = "Save Export",
+                FileName = $"{Guid.NewGuid()}.xlsx"
+            };
+
+            if (saveFileDialog.ShowDialog() != DialogResult.OK)
+            {
+                MessageBox.Show("Export Cancelled", "Cancelled", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            try
+            {
+                using (ExcelEngine excelEngine = new ExcelEngine())
+                {
+                    IWorkbook workbook = excelEngine.Excel.Workbooks.Create();
+                    IWorksheet worksheet = workbook.Worksheets[0];
 
                     // Write column headers
                     int columnIndex = 1;
-                    foreach (var column in visibleColumns)
+                    foreach (var column in sfDataGrid.Columns)
                     {
-                        worksheet.Cells[1, columnIndex].Value = column.HeaderText;
-                        columnIndex++;
-                    }
-
-                    // Write data
-                    for (int i = 0; i < dgv.Rows.Count; i++)
-                    {
-                        int cellIndex = 1;
-                        foreach (var column in visibleColumns)
+                        if (column.Visible)
                         {
-                            worksheet.Cells[i + 2, cellIndex].Value = dgv.Rows[i].Cells[column.Index].Value;
-                            cellIndex++;
+                            worksheet[1, columnIndex].Text = column.HeaderText;
+                            columnIndex++;
                         }
                     }
 
-                    package.Save();
-                } catch (Exception ex)
-                {
-                    MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    LogManager.Error($"{ex}", nameof(DataGridViewExtensions));
+                    // Write data
+                    var dataSource = sfDataGrid.DataSource as IEnumerable<dynamic>;
+                    if (dataSource != null)
+                    {
+                        int rowIndex = 2;
+                        foreach (var item in dataSource)
+                        {
+                            int cellIndex = 1;
+                            foreach (var column in sfDataGrid.Columns)
+                            {
+                                if (column.Visible)
+                                {
+                                    var property = item.GetType().GetProperty(column.MappingName);
+                                    if (property != null)
+                                    {
+                                        var value = property.GetValue(item);
+                                        worksheet[rowIndex, cellIndex].Text = value?.ToString();
+                                    }
+                                    cellIndex++;
+                                }
+                            }
+                            rowIndex++;
+                        }
+                    }
+
+                    workbook.SaveAs(saveFileDialog.FileName);
+
+                    MessageBox.Show($"Export saved to {saveFileDialog.FileName}", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             }
-
+            catch (Exception ex)
+            {
+                MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                LogManager.Error($"{ex}", nameof(DataGridViewExtensions));
+            }
         }
     }
 }

--- a/AssetTrakr.Extensions/DataGridViewExtensions.cs
+++ b/AssetTrakr.Extensions/DataGridViewExtensions.cs
@@ -66,7 +66,7 @@ namespace AssetTrakr.Extensions
             catch (Exception ex)
             {
                 MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogManager.Error($"{ex}", nameof(DataGridViewExtensions));
+                LogManager.Error($"{ex}", typeof(DataGridViewExtensions));
             }
 
         }
@@ -144,7 +144,7 @@ namespace AssetTrakr.Extensions
             catch (Exception ex)
             {
                 MessageBox.Show($"{ex.Message} \r\nSee log for more details.", "Export Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                LogManager.Error($"{ex}", nameof(DataGridViewExtensions));
+                LogManager.Error($"{ex}", typeof(DataGridViewExtensions));
             }
         }
     }

--- a/AssetTrakr.Extensions/DataGridViewExtensions.cs
+++ b/AssetTrakr.Extensions/DataGridViewExtensions.cs
@@ -211,7 +211,6 @@ namespace AssetTrakr.Extensions
                 // Get the property name from the column
                 string propertyName = column.MappingName;
 
-
                 // Set the header text of the column to the display name and column visibility
                 column.HeaderText = propertyName.GetPropertyDisplayName<T>();
                 column.Visible = propertyName.GetPropertyVisibility<T>();

--- a/AssetTrakr.Extensions/LinqExtensions.cs
+++ b/AssetTrakr.Extensions/LinqExtensions.cs
@@ -69,7 +69,7 @@ namespace AssetTrakr.Extensions
             }
             catch (Exception ex)
             {
-                LogManager.Fatal($"{ex}");
+                LogManager.Fatal($"{ex}", typeof(LinqExtensions));
                 return false;
             }
         }

--- a/AssetTrakr.Extensions/StringToPropertyExtensions.cs
+++ b/AssetTrakr.Extensions/StringToPropertyExtensions.cs
@@ -1,0 +1,75 @@
+﻿using AssetTrakr.Utils.Attributes;
+using System.ComponentModel.DataAnnotations;
+
+namespace AssetTrakr.Extensions
+{
+    public static class StringToPropertyExtensions
+    {
+
+        /// <summary>
+        /// Get's the property Name from the Display attribute
+        /// </summary>
+        /// <typeparam name="T">
+        /// The model you want to get the property from
+        /// </typeparam>
+        /// <param name="propertyName">
+        /// The property name as a string
+        /// </param>
+        /// <example>
+        /// <code>
+        /// string displayName = string.GetPropertyDisplayName("IsArchived");
+        /// </code>
+        /// </example>
+        /// <returns>
+        /// Name field from Display attribute or propertyName if not found
+        /// </returns>
+        public static string GetPropertyDisplayName<T>(this string propertyName)
+        {
+            var property = typeof(T).GetProperties()
+                .FirstOrDefault(p => p.Name == propertyName);
+
+            if (property == null)
+            {
+                return propertyName;
+            }
+
+            var displayAttribute = property.GetCustomAttributes(typeof(DisplayAttribute), false)
+                .FirstOrDefault() as DisplayAttribute;
+
+            return displayAttribute?.Name ?? propertyName;
+        }
+
+        /// <summary>
+        /// Get's the property visibility from the custom VisibleByDefault attribute
+        /// </summary>
+        /// <typeparam name="T">
+        /// The model you want to get the property from
+        /// </typeparam>
+        /// <param name="propertyName">
+        /// The property name as a string
+        /// </param>
+        /// <example>
+        /// <code>
+        /// bool vis = string.GetPropertyVisibility("IsArchived");
+        /// </code>
+        /// </example> 
+        /// <returns>
+        /// true or false (false if not found)
+        /// </returns>
+        public static bool GetPropertyVisibility<T>(this string propertyName)
+        {
+            var property = typeof(T).GetProperties()
+                .FirstOrDefault(p => p.Name == propertyName);
+
+            if (property == null)
+            {
+                return false;
+            }
+
+            var visibilityAttribute = property.GetCustomAttributes(typeof(VisibleByDefaultAttribute), false)
+                .FirstOrDefault() as VisibleByDefaultAttribute;
+
+            return visibilityAttribute?.IsVisible ?? false;
+        }
+    }
+}

--- a/AssetTrakr.Extensions/StringToPropertyExtensions.cs
+++ b/AssetTrakr.Extensions/StringToPropertyExtensions.cs
@@ -1,5 +1,7 @@
-﻿using AssetTrakr.Utils.Attributes;
+﻿using AssetTrakr.Logging;
+using AssetTrakr.Utils.Attributes;
 using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 
 namespace AssetTrakr.Extensions
 {
@@ -25,7 +27,7 @@ namespace AssetTrakr.Extensions
         /// </returns>
         public static string GetPropertyDisplayName<T>(this string propertyName)
         {
-            var property = typeof(T).GetProperties()
+            PropertyInfo? property = typeof(T).GetProperties()
                 .FirstOrDefault(p => p.Name == propertyName);
 
             if (property == null)
@@ -33,7 +35,7 @@ namespace AssetTrakr.Extensions
                 return propertyName;
             }
 
-            var displayAttribute = property.GetCustomAttributes(typeof(DisplayAttribute), false)
+            var displayAttribute = property?.GetCustomAttributes(typeof(DisplayAttribute), false)
                 .FirstOrDefault() as DisplayAttribute;
 
             return displayAttribute?.Name ?? propertyName;
@@ -58,15 +60,15 @@ namespace AssetTrakr.Extensions
         /// </returns>
         public static bool GetPropertyVisibility<T>(this string propertyName)
         {
-            var property = typeof(T).GetProperties()
+            PropertyInfo? property = typeof(T).GetProperties()
                 .FirstOrDefault(p => p.Name == propertyName);
 
-            if (property == null)
+            if(property == null)
             {
-                return false;
+                LogManager.Warning($"{property} is null", typeof(DataGridViewExtensions));
             }
 
-            var visibilityAttribute = property.GetCustomAttributes(typeof(VisibleByDefaultAttribute), false)
+            var visibilityAttribute = property?.GetCustomAttributes(typeof(VisibleByDefaultAttribute), false)
                 .FirstOrDefault() as VisibleByDefaultAttribute;
 
             return visibilityAttribute?.IsVisible ?? false;

--- a/AssetTrakr.Extensions/TextBoxExtensions.cs
+++ b/AssetTrakr.Extensions/TextBoxExtensions.cs
@@ -1,5 +1,8 @@
-﻿namespace AssetTrakr.Extensions
+﻿using System.Runtime.Versioning;
+
+namespace AssetTrakr.Extensions
 {
+    [SupportedOSPlatform("windows")]
     public static class TextBoxExtensions
     {
         /// <summary>

--- a/AssetTrakr.FileSystem/AssetTrakr.FileSystem.csproj
+++ b/AssetTrakr.FileSystem/AssetTrakr.FileSystem.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Logging/AssetTrakr.Logging.csproj
+++ b/AssetTrakr.Logging/AssetTrakr.Logging.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Logging/LogManager.cs
+++ b/AssetTrakr.Logging/LogManager.cs
@@ -17,7 +17,6 @@ namespace AssetTrakr.Logging
                 .CreateLogger();
         }
 
-
         public static void Information<T>(string message) => Log.ForContext<T>().Information(message);
 
         /// <summary>
@@ -25,7 +24,7 @@ namespace AssetTrakr.Logging
         /// </summary>
         /// <param name="message">informational message</param>
         /// <param name="source">class name</param>
-        public static void Information(string message) => Log.Information(message);
+        public static void Information(string message, string source) => Log.Information($"[{source}] {message}");
 
         public static void Fatal<T>(string message) => Log.ForContext<T>().Fatal(message);
 
@@ -46,5 +45,12 @@ namespace AssetTrakr.Logging
         public static void Error(string message, string source) => Log.Error($"[{source}] {message}");
 
         public static void Debug<T>(string message) => Log.ForContext<T>().Debug(message);
+
+        /// <summary>
+        /// Should only be used in classes that are static where <see cref="Debug{T}(string)"/> is not suitable
+        /// </summary>
+        /// <param name="message">debug message</param>
+        /// <param name="source">class name</param>
+        public static void Debug(string message, string source) => Log.Debug($"[{source}] {message}");
     }
 }

--- a/AssetTrakr.Logging/LogManager.cs
+++ b/AssetTrakr.Logging/LogManager.cs
@@ -92,13 +92,28 @@ namespace AssetTrakr.Logging
             logger.Error(message);
         }
 
-        public static void Debug<T>(string message) => Log.ForContext<T>().Debug(message);
+        public static void Warning<T>(string message) => Log.ForContext<T>().Warning(message);
 
         /// <summary>
-        /// Should only be used in classes that are static where <see cref="Debug{T}(string)"/> is not suitable
+        /// Modified version of <see cref="Warning{T}(string)"/> that can be used on Static Classes.
         /// </summary>
-        /// <param name="message">debug message</param>
-        /// <param name="source">class name</param>
-        public static void Debug(string message, string source) => Log.Debug($"[{source}] {message}");
+        /// <param name="message">error message</param>
+        /// <param name="type">class type</param>
+        public static void Warning(string message, Type type)
+        {
+            // Get the method info for the generic method
+            var method = typeof(Log).GetMethod("ForContext", new Type[] { });
+
+            // Create the generic method using the type parameter
+            var genericMethod = method.MakeGenericMethod(type);
+
+            // Invoke the generic method to get the logger
+            var logger = genericMethod.Invoke(null, null) as ILogger;
+
+            // Use the logger to log the info message
+            logger.Warning(message);
+        }
+
+
     }
 }

--- a/AssetTrakr.Logging/LogManager.cs
+++ b/AssetTrakr.Logging/LogManager.cs
@@ -11,38 +11,86 @@ namespace AssetTrakr.Logging
 
         public LogManager(string fileName = "app.log")
         {
+
+#if DEBUG
+            // Manual override in case we're running a debug build to seperate logs
+            fileName = $"debug-{fileName}";
+#endif
+
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Information() // Adjust the minimum log level as needed
-                .WriteTo.File(Path.Combine(logPath, fileName), rollingInterval: RollingInterval.Day, outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] [{SourceContext}] {Message}{NewLine}{Exception}") // Log to file with daily rolling
+                .WriteTo.File(
+                    Path.Combine(logPath, fileName), 
+                    rollingInterval: RollingInterval.Day, 
+                    outputTemplate: "[{Timestamp:HH:mm:ss.fff zzz} {Level:u3}] [{SourceContext}] {Message}{NewLine}{Exception}") // Log to file with daily rolling
                 .CreateLogger();
         }
 
         public static void Information<T>(string message) => Log.ForContext<T>().Information(message);
 
         /// <summary>
-        /// Should only be used in classes that are static where <see cref="Information{T}(string)"/> is not suitable
+        /// Modified version of <see cref="Information{T}(string)"/> that can be used on Static Classes.
         /// </summary>
-        /// <param name="message">informational message</param>
-        /// <param name="source">class name</param>
-        public static void Information(string message, string source) => Log.Information($"[{source}] {message}");
+        /// <param name="message">error message</param>
+        /// <param name="type">class type</param>
+        public static void Information(string message, Type type)
+        {
+            // Get the method info for the generic method
+            var method = typeof(Log).GetMethod("ForContext", new Type[] { });
+
+            // Create the generic method using the type parameter
+            var genericMethod = method.MakeGenericMethod(type);
+
+            // Invoke the generic method to get the logger
+            var logger = genericMethod.Invoke(null, null) as ILogger;
+
+            // Use the logger to log the info message
+            logger.Information(message);
+        }
 
         public static void Fatal<T>(string message) => Log.ForContext<T>().Fatal(message);
 
         /// <summary>
-        /// Should only be used in classes that are static where <see cref="Fatal{T}(string)"/> is not suitable
+        /// Modified version of <see cref="Fatal{T}(string)"/> that can be used on Static Classes.
         /// </summary>
-        /// <param name="message">fatal error message</param>
-        /// <param name="source">class name</param>
-        public static void Fatal(string message) => Log.Fatal(message);
+        /// <param name="message">error message</param>
+        /// <param name="type">class type</param>
+        public static void Fatal(string message, Type type)
+        {
+            // Get the method info for the generic method
+            var method = typeof(Log).GetMethod("ForContext", new Type[] { });
+
+            // Create the generic method using the type parameter
+            var genericMethod = method.MakeGenericMethod(type);
+
+            // Invoke the generic method to get the logger
+            var logger = genericMethod.Invoke(null, null) as ILogger;
+
+            // Use the logger to log the fatal message
+            logger.Fatal(message);
+        }
 
         public static void Error<T>(string message) => Log.ForContext<T>().Error(message);
 
         /// <summary>
-        /// Should only be used in classes that are static where <see cref="Error{T}(string)"/> is not suitable
+        /// Modified version of <see cref="Error{T}(string)"/> that can be used on Static Classes.
         /// </summary>
         /// <param name="message">error message</param>
-        /// <param name="source">class name</param>
-        public static void Error(string message, string source) => Log.Error($"[{source}] {message}");
+        /// <param name="type">class type</param>
+        public static void Error(string message, Type type)
+        {
+            // Get the method info for the generic method
+            var method = typeof(Log).GetMethod("ForContext", new Type[] { });
+
+            // Create the generic method using the type parameter
+            var genericMethod = method.MakeGenericMethod(type);
+
+            // Invoke the generic method to get the logger
+            var logger = genericMethod.Invoke(null, null) as ILogger;
+
+            // Use the logger to log the fatal message
+            logger.Error(message);
+        }
 
         public static void Debug<T>(string message) => Log.ForContext<T>().Debug(message);
 

--- a/AssetTrakr.Models/AssetTrakr.Models.csproj
+++ b/AssetTrakr.Models/AssetTrakr.Models.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Models/Assets/Asset.cs
+++ b/AssetTrakr.Models/Assets/Asset.cs
@@ -34,9 +34,25 @@ namespace AssetTrakr.Models.Assets
         [VisibleByDefault(false)]
         public string? Description { get; set; }
 
+        /// <summary>
+        /// N.B: This never gets shown in the Syncfusion Datagrid.  Review comment for <see cref="Purchased"/> for more information.
+        /// As a result, VisibleByDefault is set to FALSE to prevent random re-appearance.  Manual review required in future.
+        /// </summary>
         [Display(Name = "Purchase Date", Description = "The Purchase Date of the Asset")]
-        [VisibleByDefault]
+        [VisibleByDefault(false)]
         public DateOnly PurchaseDate { get; set; }
+
+        /// <summary>
+        /// String version of <see cref="PurchaseDate"/> 
+        /// <br></br>
+        /// <remark>
+        /// N.B: For some reason Syncfusion's DataGrid doesn't seem to support 'DateOnly'?  As a result, the PurchaseDate property
+        /// never get's shown.  As a work around, we convert it to a string and then show that in the DataGrid instead.
+        /// </remark>
+        /// </summary>
+        [VisibleByDefault]
+        [Display(Name = "Purchase Date", Description = "The Purchase Date of the Asset")]
+        public string Purchased { get => PurchaseDate.ToString(); }
 
         [Display(Name = "User", Description = "The Registered User of the Asset")]
         [VisibleByDefault(false)]

--- a/AssetTrakr.Models/Assets/Asset.cs
+++ b/AssetTrakr.Models/Assets/Asset.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel;
+using AssetTrakr.Utils.Attributes;
 
 namespace AssetTrakr.Models.Assets
 {
@@ -11,61 +12,83 @@ namespace AssetTrakr.Models.Assets
     public class Asset : Base
     {
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [VisibleByDefault(false)]
         public int AssetId { get; set; }
 
         [Required]
         [MinLength(1)]
         [MaxLength(150)]
+        [Display(Name = "Name", Description = "The Name of the Asset")]
+        [VisibleByDefault]
         public required string Name { get; set; }
 
+        [Display(Name = "Model", Description = "The Model of the Asset")]
+        [VisibleByDefault]
         public required string Model { get; set; }
 
-        [DisplayName("License Key")]
+        [Display(Name = "License Key", Description = "The License Key of the Asset")]
+        [VisibleByDefault(false)]
         public string? LicenseKey { get; set; }
 
+        [Display(Name = "Description", Description = "The Description of the Asset")]
+        [VisibleByDefault(false)]
         public string? Description { get; set; }
 
-        [DisplayName("Purchase Date")]
+        [Display(Name = "Purchase Date", Description = "The Purchase Date of the Asset")]
+        [VisibleByDefault]
         public DateOnly PurchaseDate { get; set; }
 
-        [DisplayName("User")]
+        [Display(Name = "User", Description = "The Registered User of the Asset")]
+        [VisibleByDefault(false)]
         public string? RegisteredUser { get; set; }
 
-        [DisplayName("User Email")]
+        [Display(Name = "User Email", Description = "The Registered User's Email of the Asset")]
+        [VisibleByDefault(false)]
         public string? RegisteredEmail { get; set; }
 
+        [Display(Name = "Price", Description = "The Price of the Asset")]
+        [VisibleByDefault(false)]
         public decimal Price { get; set; }
 
-        [DisplayName("Order Reference")]
+        [Display(Name = "Order Reference", Description = "The Order Reference/ID of the Asset Invoice")]
+        [VisibleByDefault(false)]
         public string? OrderReference { get; set; }
 
-        [DisplayName("Has Warranty")]
+        [Display(Name = "Has Warranty", Description = "Whether or not the Asset is Under Warranty")]
+        [VisibleByDefault]
         public bool IsUnderWarranty { get; set; } = false;
 
-        [DisplayName("Archived")]
+        [Display(Name = "Archived", Description = "Whether or not the contract is Archived")]
         public bool IsArchived { get; set; } = false;
 
-        [DisplayName("Warranties")]
+        [Display(Name = "Warranties", Description = "Any warranties assigned to the Asset")]
+        [VisibleByDefault]
         public List<AssetPeriod> AssetPeriods { get; set; } = [];
 
         /// <summary>
         /// Assigned Attachments
         /// </summary>
+        [VisibleByDefault(false)]
         public List<AssetAttachment> AssetAttachments { get; set; } = [];
 
         [ForeignKey("OperatingSystemId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault]
         public AssetOperatingSystem? OperatingSystem { get; set; } // Direct navigation property to OperatingSystem entity
 
         [ForeignKey("HardwareId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault(false)]
         public required AssetHardware Hardware { get; set; } // Direct navigation property to Hardware entity
 
         [ForeignKey("ContractId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault(false)]
         public Contract? Contract { get; set; } // Direct navigation property to Contract entity
 
         [ForeignKey("ManufacturerId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault]
         public Manufacturer? Manufacturer { get; set; } // Direct navigation property to Manufacturer entity
 
         [ForeignKey("PlatformId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault]
         public Platform? Platform { get; set; } // Direct navigation property to Platform entity
 
     }

--- a/AssetTrakr.Models/Assets/Asset.cs
+++ b/AssetTrakr.Models/Assets/Asset.cs
@@ -70,14 +70,14 @@ namespace AssetTrakr.Models.Assets
         [VisibleByDefault(false)]
         public string? OrderReference { get; set; }
 
-        [Display(Name = "Has Warranty", Description = "Whether or not the Asset is Under Warranty")]
+        [Display(Name = "Warranty", Description = "Whether or not the Asset is Under Warranty")]
         [VisibleByDefault]
         public bool IsUnderWarranty { get; set; } = false;
 
         [Display(Name = "Archived", Description = "Whether or not the contract is Archived")]
         public bool IsArchived { get; set; } = false;
 
-        [Display(Name = "Warranties", Description = "Any warranties assigned to the Asset")]
+        [Display(Name = "Asset Periods", Description = "Any warranties assigned to the Asset")]
         [VisibleByDefault]
         public List<AssetPeriod> AssetPeriods { get; set; } = [];
 
@@ -88,6 +88,7 @@ namespace AssetTrakr.Models.Assets
         public List<AssetAttachment> AssetAttachments { get; set; } = [];
 
         [ForeignKey("OperatingSystemId")] // Define ForeignKey attribute to represent the relationship
+        [Display(Name = "Operating System", Description = "Operating System of the Asset")]
         [VisibleByDefault]
         public AssetOperatingSystem? OperatingSystem { get; set; } // Direct navigation property to OperatingSystem entity
 

--- a/AssetTrakr.Models/Assets/AssetHardware.cs
+++ b/AssetTrakr.Models/Assets/AssetHardware.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using AssetTrakr.Utils.Enums;
+using AssetTrakr.Utils.Attributes;
 
 namespace AssetTrakr.Models.Assets
 {
@@ -10,24 +10,35 @@ namespace AssetTrakr.Models.Assets
     public class AssetHardware
     {
         [Key]
+        [VisibleByDefault(false)]
         public int AssetHardwareId { get; set; }
 
+        [Display(Name = "Processor", Description = "The Processor the Asset has inside of it")]
+        [VisibleByDefault(false)]
         public string? Processor { get; set; }
 
-        [DisplayName("Ram (GB)")]
+        [Display(Name = "Ram (GB)", Description = "The amount of RAM the specific Asset has in Total")]
+        [VisibleByDefault(false)]
         public int RamSizeInGB { get; set; } = 0;
 
-        [DisplayName("Ram Sticks")]
+        [Display(Name = "Ram Sticks", Description = "The total amount of RAM Sticks within the Asset")]
+        [VisibleByDefault(false)]
         public int RamSticks { get; set; } = 0;
 
-        [DisplayName("Bios Serial Number")]
+        [Display(Name = "Serial Number", Description = "The Serial Number of the Asset")]
+        [VisibleByDefault(false)]
         public string? BiosSerialNumber { get; set; }
 
+        [Display(Name = "Network Adapters", Description = "The Network Adapters inside of the Asset")]
+        [VisibleByDefault(false)]
         public List<AssetNetworkAdapter> NetworkAdapters { get; set; } = [];
 
+        [Display(Name = "Hard Drives", Description = "The Hard Drives inside of the Asset")]
+        [VisibleByDefault(false)]
         public List<AssetHardDrive> HardDrives { get; set; } = [];
 
-        [DisplayName("Type")]
+        [Display(Name = "Type", Description = "The type of asset based on the enum AssetType")]
+        [VisibleByDefault]
         public AssetType AssetType { get; set; }
     }
 
@@ -37,38 +48,52 @@ namespace AssetTrakr.Models.Assets
         public int AssetHardwareId { get; set; }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [VisibleByDefault(false)]
         public int NetworkAdapterId { get; set; }
-        
+
+        [Display(Name = "Name", Description = "The Name of the Network Adapter")]
+        [VisibleByDefault]
         public required string Name { get; set; }
 
-        [DisplayName("IP Address")]
+        [Display(Name = "IP Address", Description = "The IP Address of the Network Adapter")]
+        [VisibleByDefault]
         public required string IpAddress { get; set; }
 
-        [DisplayName("Mac Address")]
+        [Display(Name = "Mac Address", Description = "The Mac Address of the Network Adapter")]
+        [VisibleByDefault]
         public required string MacAddress { get; set; }
 
+        [VisibleByDefault(false)]
         public AssetHardware AssetHardware { get; set; }
     }
 
     [PrimaryKey(nameof(HardDriveId))]
     public class AssetHardDrive
     {
+        [VisibleByDefault(false)]
         public int AssetHardwareId { get; set; }
 
+        [VisibleByDefault(false)]
         public int HardDriveId { get; set; }
 
+        [Display(Name = "Name", Description = "The Name of the Hard Drive")]
+        [VisibleByDefault]
         public string? Name { get; set; }
 
-        [DisplayName("Serial Number")]
+        [Display(Name = "Serial Number", Description = "The Serial Number of the Hard Drive")]
+        [VisibleByDefault]
         public string? SerialNumber { get; set; }
 
-        [DisplayName("Size")]
+        [Display(Name = "Size", Description = "The Storage Size of the Hard Drive")]
+        [VisibleByDefault]
         public int SizeInGB { get; set; }
 
 
         [ForeignKey("ManufacturerId")]
+        [VisibleByDefault(false)]
         public Manufacturer? Manufacturer { get; set; }
 
+        [VisibleByDefault(false)]
         public AssetHardware AssetHardware { get; set; }
     }
 }

--- a/AssetTrakr.Models/Base.cs
+++ b/AssetTrakr.Models/Base.cs
@@ -1,14 +1,27 @@
-﻿namespace AssetTrakr.Models
+﻿using AssetTrakr.Utils.Attributes;
+using System.ComponentModel.DataAnnotations;
+
+namespace AssetTrakr.Models
 {
     /// <summary>
     /// Includes fields that are required for all models
     /// </summary>
     public abstract class Base
     {
+        [Display(Name = "Created Date", Description = "The date the entity was created")]
+        [VisibleByDefault(false)]
         public DateTimeOffset CreatedDate { get; set; } = DateTimeOffset.Now;
+
+        [Display(Name = "Updated Date", Description = "The date the entity was last updated by a user or system")]
+        [VisibleByDefault(false)]
         public DateTimeOffset UpdatedDate { get; set; } = DateTimeOffset.Now;
 
+        [Display(Name = "Created By", Description = "Who created the entity, if left blank, returns SYSTEM")]
+        [VisibleByDefault(false)]
         public string CreatedBy { get; set; } = "SYSTEM";
+
+        [Display(Name = "Updated By", Description = "Who updated the entity, if left blank, returns SYSTEM")]
+        [VisibleByDefault(false)]
         public string UpdatedBy { get; set; } = "SYSTEM";
 
     }

--- a/AssetTrakr.Models/Contract.cs
+++ b/AssetTrakr.Models/Contract.cs
@@ -1,7 +1,6 @@
 ﻿using AssetTrakr.Utils.Attributes;
 using AssetTrakr.Utils.Enums;
 using Microsoft.EntityFrameworkCore;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 

--- a/AssetTrakr.Models/Contract.cs
+++ b/AssetTrakr.Models/Contract.cs
@@ -20,14 +20,18 @@ namespace AssetTrakr.Models
 
         [Required]
         [MaxLength(150)]
+        [Display(Name="Order Reference", Description ="Invoice Reference for Purchase")]
+        
         public required string OrderRef { get; set; } // UNIQUE
 
         [Required]
+        [Display(Name = "User Agreement Id", Description = "User/Vendor-choosen agreement Id")]
         public required string UserAgreementId { get; set; } // UNIQUE
 
         /// <summary>
         /// This is used on ComboBoxes on the 'DisplayMember' prop.
         /// </summary>
+        [Display(Name = "Name & User Agreement Id", Description = "Name and Agreement Id merged")]
         public string ComboDisplayName
         {
             get
@@ -45,6 +49,7 @@ namespace AssetTrakr.Models
 
         public decimal Price { get; set; }
 
+        [Display(Name = "Pay Frequency", Description = "Frequency that the entity is paid for")]
         public required PaymentFrequency PaymentFrequency { get; set; }
 
         [DisplayName("Archived")]

--- a/AssetTrakr.Models/Contract.cs
+++ b/AssetTrakr.Models/Contract.cs
@@ -1,4 +1,5 @@
-﻿using AssetTrakr.Utils.Enums;
+﻿using AssetTrakr.Utils.Attributes;
+using AssetTrakr.Utils.Enums;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -16,16 +17,18 @@ namespace AssetTrakr.Models
 
         [Required]
         [MaxLength(150)]
+        [VisibleByDefault]
         public required string Name { get; set; }
 
         [Required]
         [MaxLength(150)]
         [Display(Name="Order Reference", Description ="Invoice Reference for Purchase")]
-        
+        [VisibleByDefault]
         public required string OrderRef { get; set; } // UNIQUE
 
         [Required]
         [Display(Name = "User Agreement Id", Description = "User/Vendor-choosen agreement Id")]
+        [VisibleByDefault]
         public required string UserAgreementId { get; set; } // UNIQUE
 
         /// <summary>
@@ -47,12 +50,14 @@ namespace AssetTrakr.Models
             }
         }
 
+        [VisibleByDefault]
         public decimal Price { get; set; }
 
         [Display(Name = "Pay Frequency", Description = "Frequency that the entity is paid for")]
+        [VisibleByDefault]
         public required PaymentFrequency PaymentFrequency { get; set; }
 
-        [DisplayName("Archived")]
+        [Display(Name = "Archived", Description = "Whether or not the contract is Archived")]
         public bool IsArchived { get; set; } = false;
 
         /// <summary>

--- a/AssetTrakr.Models/License.cs
+++ b/AssetTrakr.Models/License.cs
@@ -3,6 +3,8 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 using System.ComponentModel;
 using AssetTrakr.Utils.Enums;
+using AssetTrakr.Utils.Attributes;
+using System.Diagnostics.CodeAnalysis;
 
 namespace AssetTrakr.Models
 {
@@ -10,79 +12,132 @@ namespace AssetTrakr.Models
     public class License : Base
     {
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [VisibleByDefault(false)]
         public int Id { get; set; }
 
         [Required]
         [MinLength(1)]
         [MaxLength(150)]
-        public string? Name { get; set; }
+        [AllowNull]
+        [VisibleByDefault]
+        [Display(Name = "Name", Description = "The Name of the License")]
+        public string Name { get; set; }
 
-        public string? Description { get; set; }
+        [AllowNull]
+        [VisibleByDefault(false)]
+        [Display(Name = "Description", Description = "The Description of the License")]
+        public string Description { get; set; }
 
         [Required]
+        [VisibleByDefault]
+        [Display(Name = "Count", Description = "The Total Entitlement Count of the License")]
         public int Count { get; set; } = 0;
 
-        [DisplayName("Purchase Date")]
+        /// <summary>
+        /// N.B: This never gets shown in the Syncfusion Datagrid.  Review comment for <see cref="Purchased"/> for more information.
+        /// As a result, VisibleByDefault is set to FALSE to prevent random re-appearance.  Manual review required in future.
+        /// </summary>
+        [Display(Name = "Purchase Date", Description = "The Purchase Date of the License")]
+        [VisibleByDefault(false)]
         public DateOnly PurchaseDate { get; set; }
+
+        /// <summary>
+        /// String version of <see cref="PurchaseDate"/> 
+        /// <br></br>
+        /// <remark>
+        /// N.B: For some reason Syncfusion's DataGrid doesn't seem to support 'DateOnly'?  As a result, the PurchaseDate property
+        /// never get's shown.  As a work around, we convert it to a string and then show that in the DataGrid instead.
+        /// </remark>
+        /// </summary>
+        [VisibleByDefault]
+        [Display(Name = "Purchase Date", Description = "The Purchase Date of the License")]
+        public string Purchased { get => PurchaseDate.ToString(); }
 
         /// <summary>
         /// Subscription Periods
         /// </summary>
+        [VisibleByDefault(false)]
+        [Display(Name = "License Periods", Description = "The Subscription Periods of the License")]
         public List<LicensePeriod> LicensePeriods { get; set; } = [];
 
-        [DisplayName("Subscription")]
+        [VisibleByDefault]
+        [Display(Name = "Subscription", Description = "Whether the license is a subscription license or not")]
         public bool IsSubscription { get; set; } = false;
 
-        [DisplayName("Subscription via Contract")]
         /// <summary>
         /// If the subscription periods are inherited from the contract
         /// </summary>
+        [VisibleByDefault(false)]
+        [Display(Name = "Subscription Inherited", Description = "Subscription is inherited from a Contract")]
         public bool IsSubscriptionContract { get; set; } = false;
 
+        [VisibleByDefault(false)]
+        [Display(Name = "Payment Freq", Description = "The frequency the license is paid for")]
         public PaymentFrequency PaymentFrequency { get; set; } = PaymentFrequency.Once;
 
         // TODO: Deprecate this
+        [VisibleByDefault(false)]
         public int? ContractId { get; set; } = 0;
 
         // TODO: Deprecate this
+        [VisibleByDefault(false)]
         public required int ManufacturerId { get; set; }
 
         /// <summary>
         /// Assigned Attachments
         /// </summary>
+        [VisibleByDefault(false)]
         public List<LicenseAttachment> LicenseAttachments { get; set; } = [];
 
+        [VisibleByDefault]
+        [Display(Name = "Price", Description = "The Price of the License")]
         public decimal Price { get; set; }
 
-        [DisplayName("Order Reference")]
-        public string? OrderReference { get; set; }
+        [VisibleByDefault(false)]
+        [Display(Name = "Order Reference", Description = "The Order Reference of the License")]
+        [AllowNull]
+        public string OrderReference { get; set; }
 
+        [VisibleByDefault(false)]
         public string? Vendor { get; set; }
 
+        [VisibleByDefault(false)]
+        [AllowNull]
+        [Display(Name = "Vendor", Description = "The Vendor the License was purchased from")]
         public string? Version { get; set; }
 
         // TODO: Deprecate this
+        [VisibleByDefault(false)]
         public int PlatformId { get; set; } = 0;
 
-        [DisplayName("Archived")]
+        [Display(Name = "Archived", Description = "Whether the license is archived or not")]
         public bool IsArchived { get; set; } = false;
 
-        [DisplayName("User")]
-        public string? RegisteredUser { get; set; }
+        [Display(Name = "User", Description = "The Registered User of the License")]
+        [VisibleByDefault(false)]
+        [AllowNull]
+        public string RegisteredUser { get; set; }
 
-        [DisplayName("User Email")]
-        public string? RegisteredEmail { get; set; }
+        [Display(Name = "User Email", Description = "The Registered User's Email of the License")]
+        [VisibleByDefault(false)]
+        [AllowNull]
+        public string RegisteredEmail { get; set; }
 
-        [DisplayName("License Key")]
-        public string? LicenseKey { get; set; }
+        [Display(Name = "License Key", Description = "The Product Key assigned to the License")]
+        [VisibleByDefault(false)]
+        [AllowNull]
+        public string LicenseKey { get; set; }
 
         [ForeignKey("ContractId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault(true)]
         public Contract? Contract { get; set; } // Direct navigation property to Contract entity
         
         [ForeignKey("ManufacturerId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault(true)]
         public Manufacturer? Manufacturer { get; set; } // Direct navigation property to Manufacturer entity
 
         [ForeignKey("PlatformId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault(true)]
         public Platform? Platform { get; set; } // Direct navigation property to Platform entity
     }
 }

--- a/AssetTrakr.Models/Platform.cs
+++ b/AssetTrakr.Models/Platform.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using AssetTrakr.Utils.Attributes;
+using Microsoft.EntityFrameworkCore;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -9,21 +10,26 @@ namespace AssetTrakr.Models
     public class Platform : Base
     {
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [VisibleByDefault(false)]
         public int PlatformId { get; set; }
 
         [Required]
         [MinLength(1)]
         [MaxLength(100)]
+        [VisibleByDefault]
         public required string Name { get; set; }
-        
+
+        [VisibleByDefault(false)]
         public string? Notes { get; set; }
 
         [DisplayName("Archived")]
         public bool IsArchived { get; set; } = false;
 
+        [VisibleByDefault(false)]
         public int ManufacturerId { get; set; }
 
         [ForeignKey("ManufacturerId")] // Define ForeignKey attribute to represent the relationship
+        [VisibleByDefault(false)]
         public required Manufacturer Manufacturer { get; set; } // Direct navigation property to Manufacturer entity
 
     }

--- a/AssetTrakr.Updater/AssetTrakr.Updater.csproj
+++ b/AssetTrakr.Updater/AssetTrakr.Updater.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Updater/CheckForUpdates.cs
+++ b/AssetTrakr.Updater/CheckForUpdates.cs
@@ -16,7 +16,7 @@ namespace AssetTrakr.Updater
         public CheckForUpdates()
         {
             _dbContext ??= new();
-            _checkForUpdates = _dbContext.SystemSettings.WhereEnabled(nameof(SystemSettings.AlertThreshold));
+            _checkForUpdates = _dbContext.SystemSettings.WhereEnabled(nameof(SystemSettings.CheckForUpdates));
 
             LogManager.Information<CheckForUpdates>($"Starting Updater Client");
         }

--- a/AssetTrakr.Utils/AssetTrakr.Utils.csproj
+++ b/AssetTrakr.Utils/AssetTrakr.Utils.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetTrakr.Utils/Attributes/UserVisible.cs
+++ b/AssetTrakr.Utils/Attributes/UserVisible.cs
@@ -1,8 +1,0 @@
-﻿namespace AssetTrakr.Utils.Attributes
-{
-    [AttributeUsage(AttributeTargets.Property)]
-    public class UserVisible : Attribute
-    {
-        public bool IsVisibleToUser { get; set; }
-    }
-}

--- a/AssetTrakr.Utils/Attributes/VisibleByDefaultAttribute.cs
+++ b/AssetTrakr.Utils/Attributes/VisibleByDefaultAttribute.cs
@@ -1,0 +1,21 @@
+﻿namespace AssetTrakr.Utils.Attributes
+{
+    /// <summary>
+    /// 
+    ///     VisibleByDefault is a general purpose attribute that can be retreived using Reflection for use on whether or not
+    ///     the property should by visible to the user by default.  For example, usage in a DataGridView for a Column Selector.
+    /// 
+    /// </summary>
+
+    [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+    public sealed class VisibleByDefaultAttribute : Attribute
+    {
+        public bool IsVisible { get; }
+
+        public VisibleByDefaultAttribute(bool isVisible = true)
+        {
+            IsVisible = isVisible;
+        }
+    }
+
+}

--- a/AssetTrakr.WinForms/AssetTrakr.WinForms.csproj
+++ b/AssetTrakr.WinForms/AssetTrakr.WinForms.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Copyright>McKenzie Software</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/INSTALLER_CONFIG.iss
+++ b/INSTALLER_CONFIG.iss
@@ -2,8 +2,8 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "AssetTrakr"
-#define MyAppVersion "1.0.6"
-#define MyAppPublisher "Laim McKenzie"
+#define MyAppVersion "1.0.7"
+#define MyAppPublisher "McKenzie Software"
 #define MyAppURL "https://assettrakr.laim.scot"
 #define MyAppExeName "AssetTrakr.App.exe"
 

--- a/README.MD
+++ b/README.MD
@@ -12,3 +12,6 @@ Download the latest release and run **AssetTrakr.App.Migrator**.  This will run 
 **Please note that building from source may prevent you from using the official releases and I cannot guarantee that migrations from official releases will work**
 
 See [Build from Source](https://github.com/Laim/assettrakr/wiki/Build-from-Source) on the Wiki.
+
+# Roadmap
+You can keep up to date with what's in progress for the next version of AssetTrakr on the [GitHub Project](https://github.com/orgs/McKenzie-Software/projects/4/views/1)

--- a/Scripts/DemoData/Contracts.py
+++ b/Scripts/DemoData/Contracts.py
@@ -1,0 +1,35 @@
+import random
+import uuid
+
+names = ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]
+order_refs = [f"ORD{str(i).zfill(4)}" for i in range(0, 100)]  # Generate 1000 unique order references
+
+created_date = "2024-05-20 22:03:02.7135149+00:00"
+updated_date = "2024-05-20 22:03:02.7135149+00:00"
+created_by = "DemoData"
+updated_by = "DemoData"
+
+def generate_insert_statements_with_unique_order_refs():
+    insert_statements = []
+    user_agreement_ids = set()
+    while len(user_agreement_ids) < 5000:
+        user_agreement_ids.add(str(uuid.uuid4()))  # Generate unique UUIDs
+
+    for user_agreement_id, order_ref in zip(user_agreement_ids, order_refs):
+        name = random.choice(names)
+        price = round(random.uniform(10.0, 1000.0), 2)
+        payment_frequency = "Once"
+        statement = f'''
+INSERT INTO Contracts (Name, OrderRef, Price, PaymentFrequency, UserAgreementId, CreatedDate, UpdatedDate, CreatedBy, UpdatedBy) 
+VALUES ("{name}", "{order_ref}", "{price}", "{payment_frequency}", "{user_agreement_id}", "{created_date}", "{updated_date}", "{created_by}", "{updated_by}");
+'''
+        insert_statements.append(statement.strip())
+    return insert_statements
+
+insert_statements_with_unique_order_refs = generate_insert_statements_with_unique_order_refs()
+
+# Save insert statements to a file
+output_path = r'C:\Development\Source Code\AssetTrakr\AssetTrakr\Scripts\DemoData\_Output\Contracts.sql'
+with open(output_path, 'w') as file:
+    for statement in insert_statements_with_unique_order_refs:
+        file.write(statement + '\n')


### PR DESCRIPTION
# Added
- Filtering and Sorting to all view all forms
- Auto-hide archive column if archive in view all isn't enabled
- New Alert on alert list if an update is available
- Custom build property /p:SyncfusionLicense=xxx
- Release channel output to logging
- Value check on CheckForUpdates to only accept stable or beta (both values currently result in the same version currently)
- GetPropertyDisplayName() and GetPropertyVisibility extensions for getting property name from DisplayAttribute and visibility from custom VisiableByDefaultAttribute
- Attribute 'VisibleByDefaultAttribute' for showing columns in DataGrid's by default or not.
- GetCurrentItemProperty<T>() and CustomColumnModifier<T>() to DataGridViewExtensions. **NOTE**:  Only supports SfDataGrid currently

# Fixed
- About Form Issue (see https://github.com/McKenzie-Software/AssetTrakr/issues/10)
- Check for updates system setting not working because WhereEnabled was looking for the wrong setting

# Changed
- Database Backup Naming Convention (see https://github.com/McKenzie-Software/AssetTrakr/issues/9)
- Migrated all DataGridView's to Syncfusion DataGrid for better performance, filtering and sorting
- *ViewAll forms are now sizable
-  Logging methods
- ColumnSelector2 now accepts DataGridView and SfDataGrid
- DataGridViewExtensions now has an Export method for DataGridView and SfDataGrid
- Required field notification in AssetModify and LicenseModify
- ColumnSelector2 to use .HeaderText instead of .MappingName

# Removed
- Removed unused Attribute "UserVisible"